### PR TITLE
Fix execstart in dist/prise.service for linux

### DIFF
--- a/dist/prise.service
+++ b/dist/prise.service
@@ -4,7 +4,7 @@ Documentation=https://prise.sh
 
 [Service]
 Type=simple
-ExecStart=prise serve
++ExecStart=%h/.local/bin/prise serve
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
I got claude to take a look you can see the session here : https://opencode.ai/s/0HZJiDvq

Looks like exec start was causing the issue on linux changed it from

ExecStart=prise serve 

to 

ExecStart=%h/.local/bin/prise serve

Which fixed the issue for me