### PR TITLE
Detach from current session with `leader + d`

### DIFF
--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1420,7 +1420,7 @@ function M.update(event)
                 handled = true
             elseif k == "d" then
                 -- Detach from session
-                prise.detach(prise.next_session_name())
+                prise.detach(prise.get_session_name())
                 handled = true
             elseif k == "t" then
                 -- New tab


### PR DESCRIPTION
Currently, when using `leader + d` to detach from a session, `prise.next_session_name` is used rather than detaching from the current session with `prise.get_session_name`. This introduces odd behavior where a duplicate session with a randomized name is generated.

When using `leader + q` to quit the current session, it works as expected.