### PR TITLE
improve pane resize to work with any child in multi-pane layouts

### DIFF
--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -800,6 +800,10 @@ local function adjust_pair(split, left_idx, right_idx, delta)
     local right_r = effective_ratio(split, right_idx)
     local total = left_r + right_r
 
+    if total < 2 * MIN_PANE_SHARE then
+        return
+    end
+
     local new_left = left_r + delta
 
     -- Clamp so each keeps at least MIN_PANE_SHARE


### PR DESCRIPTION
Previously resize only worked for the first child in a split. Now each pane can resize its adjacent divider:
- "Resize left/up" shrinks the left/top neighbor
- "Resize right/down" grows the current pane
- Edge panes without a neighbor in that direction do nothing