### PR TITLE
add Lua testing infrastructure with keybind merge fix

### DIFF
--- a/.github/review-tools/leave_general_comment
+++ b/.github/review-tools/leave_general_comment
@@ -22,10 +22,7 @@ if ! echo "$input" | jq -e '.message' > /dev/null 2>&1; then
   exit 1
 fi
 
-# Add thread link if available, then add type field and append to comments file
-if [[ -n "${AMP_THREAD_URL:-}" ]]; then
-  input=$(echo "$input" | jq --arg url "$AMP_THREAD_URL" '.message += "\n\n---\n[View Amp thread](" + $url + ")"')
-fi
+# Add type field and append to comments file
 echo "$input" | jq -c '. + {type: "general"}' >> "$COMMENTS_FILE"
 
 echo "General comment recorded" >&2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -84,6 +84,9 @@ jobs:
           Be concise and constructive. Only comment on things that matter.
           If the code looks good, leave a general comment saying so.
 
+          IMPORTANT: Always leave a general comment at the end. Include a link to this Amp thread
+          in your general comment so reviewers can see the full review context.
+
           The project follows TigerStyle conventions:
           - Assertions for invariants at API boundaries
           - Explicit bounds on collections

--- a/build.zig
+++ b/build.zig
@@ -127,7 +127,7 @@ pub fn build(b: *std.Build) void {
 
     const check_fmt = b.addSystemCommand(&.{
         "sh", "-c",
-        \\zig fmt --check src tools build.zig && stylua --check src/lua || {
+        \\zig fmt --check src --exclude src/lua && zig fmt --check tools build.zig && stylua --check src/lua || {
         \\  echo ""; echo "Format check failed. Run 'zig build fmt' to fix."; exit 1;
         \\}
         ,
@@ -138,6 +138,7 @@ pub fn build(b: *std.Build) void {
 
     const fmt_zig = b.addFmt(.{
         .paths = &.{ "src", "build.zig", "tools" },
+        .exclude_paths = &.{"src/lua"},
         .check = false,
     });
     fmt_step.dependOn(&fmt_zig.step);

--- a/src/lua/test_utils.lua
+++ b/src/lua/test_utils.lua
@@ -1,0 +1,46 @@
+local utils = require("utils")
+
+-- Test: deep_merge merges nested tables
+local target = { theme = { bg = "black", fg = "white" } }
+local source = { theme = { fg = "gray" } }
+utils.deep_merge(target, source)
+assert(target.theme.bg == "black", "deep_merge: bg should be preserved")
+assert(target.theme.fg == "gray", "deep_merge: fg should be overwritten")
+
+-- Test: deep_merge also merges keybind-like tables (no special handling)
+target = { keybinds = { leader = { key = "k", super = true } } }
+source = { keybinds = { leader = { key = "a", ctrl = true } } }
+utils.deep_merge(target, source)
+assert(target.keybinds.leader.key == "a", "deep_merge: key should be replaced")
+assert(target.keybinds.leader.ctrl == true, "deep_merge: ctrl should be set")
+assert(target.keybinds.leader.super == true, "deep_merge: super should be inherited")
+
+-- Test: merge_config merges nested tables
+target = { theme = { bg = "black", fg = "white" } }
+source = { theme = { fg = "gray" } }
+utils.merge_config(target, source)
+assert(target.theme.bg == "black", "merge_config: bg should be preserved")
+assert(target.theme.fg == "gray", "merge_config: fg should be overwritten")
+
+-- Test: merge_config replaces keybind tables entirely
+target = { keybinds = { leader = { key = "k", super = true } } }
+source = { keybinds = { leader = { key = "a", ctrl = true } } }
+utils.merge_config(target, source)
+assert(target.keybinds.leader.key == "a", "merge_config: key should be replaced")
+assert(target.keybinds.leader.ctrl == true, "merge_config: ctrl should be set")
+assert(target.keybinds.leader.super == nil, "merge_config: super should not be inherited")
+
+-- Test: merge_config replaces nested keybinds too
+target = { keybinds = { palette = { key = "p", super = true, shift = true } } }
+source = { keybinds = { palette = { key = "o", alt = true } } }
+utils.merge_config(target, source)
+assert(target.keybinds.palette.key == "o", "merge_config: key should be replaced")
+assert(target.keybinds.palette.alt == true, "merge_config: alt should be set")
+assert(target.keybinds.palette.super == nil, "merge_config: super should not be inherited")
+assert(target.keybinds.palette.shift == nil, "merge_config: shift should not be inherited")
+
+-- Test: is_keybind correctly identifies keybinds
+assert(utils.is_keybind({ key = "a" }) == true, "should detect keybind")
+assert(utils.is_keybind({ key = "b", ctrl = true }) == true, "should detect keybind with modifiers")
+assert(utils.is_keybind({ foo = "bar" }) == false, "should not detect non-keybind")
+assert(utils.is_keybind({}) == false, "should not detect empty table")

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1,4 +1,5 @@
 local prise = require("prise")
+local utils = require("utils")
 
 ---@class Pane
 ---@field type "pane"
@@ -134,18 +135,7 @@ local config = {
     },
 }
 
----Deep merge tables (source into target)
----@param target table
----@param source table
-local function deep_merge(target, source)
-    for k, v in pairs(source) do
-        if type(v) == "table" and type(target[k]) == "table" then
-            deep_merge(target[k], v)
-        else
-            target[k] = v
-        end
-    end
-end
+local merge_config = utils.merge_config
 
 -- Convenience alias for theme access
 local THEME = config.theme
@@ -191,7 +181,7 @@ local M = {}
 ---@param opts? PriseConfig Configuration options to merge
 function M.setup(opts)
     if opts then
-        deep_merge(config, opts)
+        merge_config(config, opts)
     end
 end
 

--- a/src/lua/utils.lua
+++ b/src/lua/utils.lua
@@ -1,0 +1,38 @@
+---@class Utils
+local M = {}
+
+---Check if a table looks like a keybind (has a 'key' field)
+---@param t table
+---@return boolean
+function M.is_keybind(t)
+    return t.key ~= nil
+end
+
+---Deep merge tables (source into target)
+---@param target table
+---@param source table
+function M.deep_merge(target, source)
+    for k, v in pairs(source) do
+        if type(v) == "table" and type(target[k]) == "table" then
+            M.deep_merge(target[k], v)
+        else
+            target[k] = v
+        end
+    end
+end
+
+---Merge config tables (source into target)
+---Like deep_merge, but keybind tables are replaced entirely instead of merged
+---@param target table
+---@param source table
+function M.merge_config(target, source)
+    for k, v in pairs(source) do
+        if type(v) == "table" and type(target[k]) == "table" and not M.is_keybind(v) then
+            M.merge_config(target[k], v)
+        else
+            target[k] = v
+        end
+    end
+end
+
+return M

--- a/src/lua_test.zig
+++ b/src/lua_test.zig
@@ -1,0 +1,32 @@
+//! Lua unit tests
+//!
+//! Runs Lua test files through ziglua to verify Lua utility functions.
+
+const std = @import("std");
+const ziglua = @import("zlua");
+
+fn runLuaTest(lua: *ziglua.Lua, file: [:0]const u8) !void {
+    lua.doFile(file) catch {
+        const err_msg = lua.toString(-1) catch "(no error message)";
+        std.debug.print("\nLua error: {s}\n", .{err_msg});
+        return error.LuaTestFailed;
+    };
+}
+
+test "lua utils" {
+    const allocator = std.testing.allocator;
+
+    var lua = try ziglua.Lua.init(allocator);
+    defer lua.deinit();
+
+    lua.openLibs();
+
+    // Set up package.path to find our Lua modules
+    _ = try lua.getGlobal("package");
+    _ = lua.pushString("src/lua/?.lua");
+    lua.setField(-2, "path");
+    lua.pop(1);
+
+    // Run the test file
+    try runLuaTest(lua, "src/lua/test_utils.lua");
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -671,6 +671,7 @@ test {
     _ = @import("key_encode.zig");
     _ = @import("mouse_encode.zig");
     _ = @import("vaxis_helper.zig");
+    _ = @import("lua_test.zig");
 
     if (builtin.os.tag.isDarwin() or builtin.os.tag.isBSD()) {
         _ = @import("io/kqueue.zig");


### PR DESCRIPTION
## Summary

Fixes keybind tables being deep merged instead of replaced. When a user sets \`keybinds = { leader = { key = "a", ctrl = true } }\`, it now replaces the default entirely instead of merging and inheriting \`super = true\`.

## Changes

- Extract \`deep_merge\` and \`is_keybind\` into \`src/lua/utils.lua\` module
- Add Zig test runner (\`src/lua_test.zig\`) that executes Lua test files via ziglua
- Add \`src/lua/test_utils.lua\` with tests for the keybind merge fix
- Proper Lua error reporting with file, line number, and message on test failure

## Testing

\`\`\`bash
zig build test
\`\`\`