### PR TITLE
Load `utils` on build and fix tiling regressions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,6 +48,7 @@ pub fn build(b: *std.Build) void {
 
     b.installFile("src/lua/prise.lua", "share/prise/lua/prise.lua");
     b.installFile("src/lua/tiling.lua", "share/prise/lua/prise_tiling_ui.lua");
+    b.installFile("src/lua/utils.lua", "share/prise/lua/utils.lua");
 
     const os = @import("builtin").os.tag;
     if (os.isDarwin()) {

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1968,7 +1968,6 @@ local function build_palette()
     end
 
     local palette_style = { bg = THEME.bg1, fg = THEME.fg_bright }
-    local palette_style = { bg = THEME.bg1, fg = palette_fg }
     local selected_style = { bg = THEME.accent, fg = THEME.fg_dark }
     local input_style = { bg = THEME.bg1, fg = THEME.fg_bright }
 
@@ -2034,7 +2033,6 @@ local function build_rename()
     end
 
     local palette_style = { bg = THEME.bg1, fg = THEME.fg_bright }
-    local palette_style = { bg = THEME.bg1, fg = palette_fg }
     local input_style = { bg = THEME.bg1, fg = THEME.fg_bright }
 
     return prise.Positioned({
@@ -2072,7 +2070,6 @@ local function build_rename_tab()
     end
 
     local palette_style = { bg = THEME.bg1, fg = THEME.fg_bright }
-    local palette_style = { bg = THEME.bg1, fg = palette_fg }
     local input_style = { bg = THEME.bg1, fg = THEME.fg_bright }
 
     return prise.Positioned({

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -162,8 +162,9 @@ pub const UI = struct {
                 return error.DefaultUIFailed;
             };
         } else {
-            lua.doFile(config_path) catch |err| {
-                log.err("Failed to load init.lua: {}", .{err});
+            lua.doFile(config_path) catch {
+                const msg = lua.toString(-1) catch "unknown error";
+                log.err("Failed to load init.lua: {s}", .{msg});
                 return error.InitLuaFailed;
             };
         }


### PR DESCRIPTION
There were some regressions with previous commits where `palette_fg` wasnt properly cleaned up as it is no longer defined. This removes the duplicate `palette_style`s that use that variable. This also loads utils on build and updates logging. The provided AI conversation provides more context on that issue but main point of issue:

```
line 2 of tiling.lua does require("utils"), and utils.lua is not being installed.
```

Context: [AI Conversation](https://opencode.ai/s/6uI2VPVT)