### PR TITLE
Add CLI flag to name session during creation

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -603,7 +603,9 @@ pub const App = struct {
     ui: UI = undefined,
     first_resize_done: bool = false,
     socket_path: []const u8 = undefined,
+    /// Session name to attach to (existing session passed via `prise session attach <name>`)
     attach_session: ?[]const u8 = null,
+    /// User-specified session name for new session (passed via `prise -s <name>`)
     new_session_name: ?[]const u8 = null,
     initial_cwd: ?[]const u8 = null,
     last_render_time: i64 = 0,


### PR DESCRIPTION
This PR provides an optional CLI flag to name the session you are creating. It holds backwards compatibility so that `prise` as an isolated command will still generate a name for the session, but if passed a flag with an appropriate argument:

```bash
prise -s session_name
```

it will create a session with that provided name.

Context: [AI Conversation](https://opencode.ai/s/6yYghkyb)