### PR TITLE
Add session switching keybind

### DIFF
--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1667,6 +1667,38 @@ function M.update(event)
                 -- Quit
                 prise.detach(prise.get_session_name())
                 handled = true
+            elseif k == "(" then
+                -- Previous session
+                local sessions = prise.list_sessions()
+                if #sessions > 1 then
+                    local current = prise.get_session_name()
+                    local current_idx = 1
+                    for i, name in ipairs(sessions) do
+                        if name == current then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local prev_idx = (current_idx - 2 + #sessions) % #sessions + 1
+                    prise.switch_session(sessions[prev_idx])
+                end
+                handled = true
+            elseif k == ")" then
+                -- Next session
+                local sessions = prise.list_sessions()
+                if #sessions > 1 then
+                    local current = prise.get_session_name()
+                    local current_idx = 1
+                    for i, name in ipairs(sessions) do
+                        if name == current then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = current_idx % #sessions + 1
+                    prise.switch_session(sessions[next_idx])
+                end
+                handled = true
             elseif k == "z" then
                 -- Toggle zoom
                 if state.zoomed_pane_id then

--- a/src/session.zig
+++ b/src/session.zig
@@ -1,0 +1,67 @@
+//! Session management utilities.
+//!
+//! Provides shared helpers for session file operations used by both
+//! the CLI (main.zig) and the client application (client.zig).
+
+const std = @import("std");
+
+pub const SessionsDir = struct {
+    dir: std.fs.Dir,
+    path: []const u8,
+
+    pub fn deinit(self: *SessionsDir, allocator: std.mem.Allocator) void {
+        self.dir.close();
+        allocator.free(self.path);
+    }
+};
+
+pub fn getSessionsDir(allocator: std.mem.Allocator) !SessionsDir {
+    const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
+    const sessions_dir = try std.fs.path.join(allocator, &.{ home, ".local", "state", "prise", "sessions" });
+
+    const dir = std.fs.openDirAbsolute(sessions_dir, .{ .iterate = true }) catch |err| {
+        allocator.free(sessions_dir);
+        if (err == error.FileNotFound) {
+            return error.NoSessionsFound;
+        }
+        return err;
+    };
+
+    return .{ .dir = dir, .path = sessions_dir };
+}
+
+pub fn getSessionNames(allocator: std.mem.Allocator) ![][]const u8 {
+    var result = getSessionsDir(allocator) catch |err| {
+        if (err == error.NoSessionsFound) {
+            return allocator.alloc([]const u8, 0);
+        }
+        return err;
+    };
+    defer result.deinit(allocator);
+
+    var sessions: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (sessions.items) |s| {
+            allocator.free(s);
+        }
+        sessions.deinit(allocator);
+    }
+
+    var iter = result.dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".json")) continue;
+
+        const name_without_ext = entry.name[0 .. entry.name.len - 5];
+        try sessions.append(allocator, try allocator.dupe(u8, name_without_ext));
+    }
+
+    return sessions.toOwnedSlice(allocator);
+}
+
+pub fn freeSessionNames(allocator: std.mem.Allocator, names: [][]const u8) void {
+    for (names) |name| {
+        allocator.free(name);
+    }
+    allocator.free(names);
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/79a5ba39-4995-4233-a8fa-116cf2011100

## Session Switching

Adds the ability to switch between sessions prise sessions with `LEADER+(` and `LEADER+)` keybindings (as tmux supports).

### Changes

- Keybindings - `<prefix>(` / `<prefix>)` cycle previous/next session by invoking `prise.list_sessions` and `prise.switch_session(name)` in Lua
- UI callbacks: `prise.list_sessions()` and `prise.switch_session(name)` exposed to Lua
- RPC layer - Added `switch_session` request/response type. The `switch_session` request is identical to the `detach` request. The response handler initiates attaching the next session.

- Refactored `clearSurfaces()` and `sendDetachPtysRequest()` for reuse to share between switch_session and detach flows
- Factored out common session directory utilities into `session.zig`

### Flow

User triggers `LEADER+)` → current session saved → detach RPC sent with next target session name → server responds → surfaces cleared → next session loaded via `startSessionAttach()`