### PR TITLE
entering leader twice sends key combo to inner shell

### DIFF
--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1519,6 +1519,21 @@ function M.update(event)
             local handled = false
             local k = event.data.key
 
+            -- Leader twice sends leader to inner shell (like tmux)
+            if matches_keybind(event.data, config.keybinds.leader) then
+                local pty = get_focused_pty()
+                if pty then
+                    pty:send_key(event.data)
+                end
+                if state.timer then
+                    state.timer:cancel()
+                    state.timer = nil
+                end
+                state.pending_command = false
+                prise.request_frame()
+                return
+            end
+
             if k == "h" then
                 move_focus("left")
                 handled = true


### PR DESCRIPTION
This mimics tmux's behavior of sending the leader key combo to the inner shell if it is entered twice.

(I personally want this because I have the leader hotkeyed to `ctrl+g`, which also maps to the emacs universal "quit" command.)