### PR TITLE
fix: add homebrew lua library path

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -107,7 +107,7 @@ pub const UI = struct {
 
         const extra_paths = try std.fmt.allocPrint(
             allocator,
-            "{s}/.local/share/prise/lua/?.lua;/usr/local/share/prise/lua/?.lua;/usr/share/prise/lua/?.lua;{s}",
+            "{s}/.local/share/prise/lua/?.lua;/usr/local/share/prise/lua/?.lua;/usr/share/prise/lua/?.lua;/opt/homebrew/share/prise/lua/?.lua;{s}",
             .{ home, current_path },
         );
         defer allocator.free(extra_paths);


### PR DESCRIPTION
When installing `prise` through homebrew the lua files get copied to
`/opt/homebrew/share/prise/lua`. This causes the application to fail on
session attachment.

This adds the missing path to the lua extra paths.
