### PR TITLE
feat: add direct keybinding without prefix key

### DIFF
--- a/src/lua/types/keybinds.lua
+++ b/src/lua/types/keybinds.lua
@@ -1,0 +1,22 @@
+---@meta
+
+---@class PriseKeybind
+---@field key string the key (e.g., "k", "p", "Enter")
+---@field ctrl? boolean require ctrl modifier
+---@field alt? boolean require alt modifier
+---@field shift? boolean require shift modifier
+---@field super? boolean require super/cmd modifier
+
+---@class PriseDirectKeybind
+---@field key string the key (e.g., "h", "j", "k", "l")
+---@field ctrl? boolean require ctrl modifier
+---@field alt? boolean require alt modifier
+---@field shift? boolean require shift modifier
+---@field super? boolean require super/cmd modifier
+---@field action string action name to execute (e.g., "focus_left", "resize_right")
+---@field params? table optional parameters for the action
+
+---@class PriseKeybinds
+---@field leader? PriseKeybind key to enter command mode (default: super+k)
+---@field palette? PriseKeybind key to open command palette (default: super+p)
+---@field direct? PriseDirectKeybind[] direct keybindings that bypass prefix mode


### PR DESCRIPTION
Add direct keybinding support that bypasses prefix key while maintaining 100% backward compatibility.

## Summary

This PR adds direct keybinding support to prise, allowing users to configure key combinations that bypass the tmux-style prefix key entirely. The feature includes:

- **Action registry system**: All internal pane, tab, session, and focus actions are now exposed through a centralized registry
- **Direct keybind parser**: Parse and match direct keybindings from configuration
- **Priority system**: Prefix mode takes precedence over direct keybinds for backward compatibility
- **Default bindings**: ctrl+hjkl for focus navigation, alt+hjkl for pane resizing
- **Type safety**: Full EmmyLua type annotations for configuration
- **Comprehensive tests**: Full test coverage for all new functionality

## Configuration Example

```lua
local ui = require("tiling")

ui.setup({
    keybinds = {
        -- Traditional prefix mode (still works)
        leader = { key = "k", super = true },
        palette = { key = "p", super = true },
        
        -- NEW: Direct keybindings
        direct = {
            -- Focus navigation (vim-style)
            { key = "h", ctrl = true, action = "focus_left" },
            { key = "j", ctrl = true, action = "focus_down" },
            { key = "k", ctrl = true, action = "focus_up" },
            { key = "l", ctrl = true, action = "focus_right" },
            
            -- Pane resizing
            { key = "h", alt = true, action = "resize_left" },
            { key = "j", alt = true, action = "resize_down" },
            { key = "k", alt = true, action = "resize_up" },
            { key = "l", alt = true, action = "resize_right" },
            
            -- custom bindings with parameters
            { key = "h", alt = true, shift = true, action = "resize_left", params = { step = 0.2 } },
            
            -- tab management với super key
            { key = "t", super = true, action = "new_tab" },
            { key = "w", super = true, action = "close_tab" },
            { key = "1", super = true, action = "switch_tab", params = { index = 1 } },
            { key = "2", super = true, action = "switch_tab", params = { index = 2 } },
        }
    }
})
```

## Key Features

- ✅ **Backward compatible**: Existing prefix-based configurations work unchanged
- ✅ **Priority system**: Prefix mode checked first, direct keybinds as fallback
- ✅ **Default bindings**: Sensible defaults for common use cases
- ✅ **Parameter support**: Actions can receive custom parameters
- ✅ **Type safe**: Full type annotations for configuration
- ✅ **Well tested**: Comprehensive test coverage

## Available Actions

| category | action name | parameters |
|----------|-------------|------------|
| focus | focus_left, focus_right, focus_up, focus_down | none |
| resize | resize_left, resize_right, resize_up, resize_down | {step: number} (default: 0.05) |
| split | split_horizontal, split_vertical, split_auto | none |
| tab | new_tab, close_tab, next_tab, previous_tab, rename_tab | none |
| tab | switch_tab | {index: number} |
| pane | close_pane, toggle_zoom | none |
| session | detach, rename_session, quit | none |

## Implementation Details

- Added configuration types in `src/lua/types/keybinds.lua`
- Centralized action registry in `src/lua/tiling.lua`
- Direct keybind parser and matcher functions
- Event routing integration with proper priority ordering
- Comprehensive test coverage in `src/lua/tiling_test.lua`

This feature enables users to have both traditional tmux-style prefix keybindings AND modern direct keybindings, providing the best of both worlds for efficient terminal multiplexer usage.