### PR TITLE
separator: add segmented focus highlighting for nested splits

### DIFF
--- a/src/lua/prise.lua
+++ b/src/lua/prise.lua
@@ -250,10 +250,16 @@ function M.Box(opts)
     }
 end
 
+---@class SeparatorSegment
+---@field ratio_start number Start position as ratio (0.0-1.0)
+---@field ratio_end number End position as ratio (0.0-1.0)
+---@field style? table
+
 ---@class SeparatorOpts
 ---@field axis "horizontal"|"vertical" Separator orientation
----@field style? table Style options (fg, bg, etc.)
+---@field style? table Default style options (fg, bg, etc.)
 ---@field border? "none"|"single"|"double"|"rounded" Line style (default: "single")
+---@field segments? SeparatorSegment[] Optional per-section styles
 
 ---Create a separator widget for tmux-style pane borders
 ---@param opts SeparatorOpts
@@ -264,6 +270,7 @@ function M.Separator(opts)
         axis = opts.axis or "vertical",
         style = opts.style,
         border = opts.border or "single",
+        segments = opts.segments,
     }
 end
 


### PR DESCRIPTION
## Summary
- Extend `separator` widgets to optionally accept `segments` so a single divider can render with different styles along its length.
- Use segmented separators in tiling “separator mode” so only the portion adjacent to the focused pane highlights in nested layouts (tmux-like).

## Why
- Current behavior highlights the entire divider if any adjacent subtree contains focus, which is visually noisy in nested splits.
- Segmented styling makes focus indication precise while keeping the existing tmux-style separator approach (and border styles like `single`/`double`/`rounded`).

## Testing
- `zig build test`

## Notes
- API is backward compatible: if `segments` is omitted, rendering matches current behavior.