### PR TITLE
ignore io_uring signal interrupts

### DIFF
--- a/src/io/io_uring.zig
+++ b/src/io/io_uring.zig
@@ -12,7 +12,7 @@ const log = std.log.scoped(.io_uring);
 const RING_ENTRIES: u13 = 256;
 const CQE_BATCH_SIZE: usize = 32;
 
-fn noopSignalHandler(_: c_int) callconv(std.builtin.CallingConvention.c) void {}
+fn noopSignalHandler(_: c_int) callconv(.c) void {}
 
 pub const Loop = struct {
     allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary
- ignore SignalInterrupt from io_uring copy_cqes so the event loop retries
- add a regression test that sends SIGUSR1 to the loop thread and verifies the timer still fires

## Reason
Ghostty tab changes can deliver signals that interrupt io_uring waits; this prevents the client loop from exiting on SignalInterrupt.

## Test Plan
- [x] zig build fmt
- [ ] zig build (fails: lua-language-server typecheck errors in src/lua/tiling.lua)
- [x] zig build test

## Reference
- https://github.com/rockorager/prise/issues/72
