### PR TITLE
feat: add rename session to switch session picker

### DIFF
--- a/src/lua/types/prise.lua
+++ b/src/lua/types/prise.lua
@@ -104,9 +104,10 @@ function prise.save() end
 ---@return string?
 function prise.get_session_name() end
 
----Rename the current session
----@param new_name string
-function prise.rename_session(new_name) end
+---Rename a session
+---@param old_name string The current session name
+---@param new_name string The new session name
+function prise.rename_session(old_name, new_name) end
 
 ---Delete a session
 ---@param session_name string

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -85,7 +85,7 @@ pub const UI = struct {
     switch_session_ctx: *anyopaque = undefined,
     get_session_name_callback: ?*const fn (ctx: *anyopaque) ?[]const u8 = null,
     get_session_name_ctx: *anyopaque = undefined,
-    rename_session_callback: ?*const fn (ctx: *anyopaque, new_name: []const u8) anyerror!void = null,
+    rename_session_callback: ?*const fn (ctx: *anyopaque, old_name: []const u8, new_name: []const u8) anyerror!void = null,
     rename_session_ctx: *anyopaque = undefined,
     delete_session_callback: ?*const fn (ctx: *anyopaque, session_name: []const u8) anyerror!void = null,
     delete_session_ctx: *anyopaque = undefined,
@@ -254,7 +254,7 @@ pub const UI = struct {
         self.get_session_name_callback = cb;
     }
 
-    pub fn setRenameSessionCallback(self: *UI, ctx: *anyopaque, cb: *const fn (ctx: *anyopaque, new_name: []const u8) anyerror!void) void {
+    pub fn setRenameSessionCallback(self: *UI, ctx: *anyopaque, cb: *const fn (ctx: *anyopaque, old_name: []const u8, new_name: []const u8) anyerror!void) void {
         self.rename_session_ctx = ctx;
         self.rename_session_callback = cb;
     }
@@ -541,13 +541,18 @@ pub const UI = struct {
         };
         lua.pop(1);
 
-        const new_name = lua.toString(1) catch {
+        const old_name = lua.toString(1) catch {
+            lua.pushBoolean(false);
+            return 1;
+        };
+
+        const new_name = lua.toString(2) catch {
             lua.pushBoolean(false);
             return 1;
         };
 
         if (ui.rename_session_callback) |cb| {
-            cb(ui.rename_session_ctx, new_name) catch |err| {
+            cb(ui.rename_session_ctx, old_name, new_name) catch |err| {
                 lua.raiseErrorStr("Failed to rename session: %s", .{@errorName(err).ptr});
             };
             lua.pushBoolean(true);


### PR DESCRIPTION
Following PR #70 

This PR Allows renaming any session directly from the session picker using Shift+R, with immediate list refresh.

Feature Video: 

https://github.com/user-attachments/assets/8752239e-315d-48b5-8683-ba8a045ee783


amp: https://ampcode.com/threads/T-019b6627-f63e-7398-b487-73b76c8aca44