### PR TITLE
enhancements on floating terminal pane 

### DIFF
--- a/docs/prise.5.md
+++ b/docs/prise.5.md
@@ -433,9 +433,6 @@ The tiling UI uses a leader key sequence. Press the leader key (default:
 **-**
 :   Decrease floating pane size
 
-**Escape**
-:   Hide floating pane (when visible)
-
 The command palette (**Super+p**) provides fuzzy search for all commands.
 
 # SEE ALSO


### PR DESCRIPTION
enhancements for floating terminal panes following #80 
- fix Cmd+C/Cmd+V routing, which blocked copy/paste in floating panes
- remove Esc-to-close behavior (conflicts with vim)
-  route key_release, focus_in, and focus_out events to floating pane when visible
- refactored duplicated logic for getting the focused_pty on the way