### PR TITLE
fix: include Space in isNamedKey for keybind matching

### DIFF
--- a/src/vaxis_helper.zig
+++ b/src/vaxis_helper.zig
@@ -37,6 +37,7 @@ fn isNamedKey(codepoint: u21) bool {
         Key.tab,
         Key.backspace,
         Key.escape,
+        Key.space,
         Key.delete,
         Key.insert,
         Key.home,


### PR DESCRIPTION
Space was missing from `isNamedKey` in `vaxis_helper.zig`. Config parser turns `<C-Space>` into key `"Space"` but the runtime produced `" "` (literal char) since Space fell through to UTF-8 encoding. Leader and any Space-based keybinds could never match.