### PR TITLE
Session switching without exec + predefined layouts

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -1842,7 +1842,7 @@ pub const App = struct {
         try self.ui.clearState();
     }
 
-    fn cancelSessionSwitch(self: *App) void {
+    fn finishSessionSwitch(self: *App) void {
         self.session_switch_in_progress = false;
         self.state.suppress_unsolicited_pty_results = false;
         if (self.switch_target_session) |target| {
@@ -1851,13 +1851,12 @@ pub const App = struct {
         }
     }
 
+    fn cancelSessionSwitch(self: *App) void {
+        self.finishSessionSwitch();
+    }
+
     fn completeSessionSwitch(self: *App) void {
-        self.session_switch_in_progress = false;
-        self.state.suppress_unsolicited_pty_results = false;
-        if (self.switch_target_session) |target| {
-            self.allocator.free(target);
-            self.switch_target_session = null;
-        }
+        self.finishSessionSwitch();
     }
 
     fn beginSessionSwitchAttach(self: *App) !void {

--- a/src/client.zig
+++ b/src/client.zig
@@ -18,6 +18,11 @@ const log = std.log.scoped(.client);
 
 const MAX_PASTE_SIZE = 10 * 1024 * 1024; // 10 MiB
 
+fn nonEmptyCwd(cwd: ?[]const u8) ?[]const u8 {
+    const value = cwd orelse return null;
+    return if (value.len > 0) value else null;
+}
+
 pub const MsgId = enum(u16) {
     spawn_pty = 1,
     attach_pty = 2,
@@ -292,7 +297,7 @@ pub const ClientLogic = struct {
                 .attach => |attach_info| {
                     state.pty_id = attach_info.pty_id;
                     state.attached = true;
-                    if (attach_info.cwd) |c| {
+                    if (nonEmptyCwd(attach_info.cwd)) |c| {
                         const owned_cwd = state.allocator.dupe(u8, c) catch return .{ .attached = .{ .new_pty_id = attach_info.pty_id } };
                         state.cwd_map.put(attach_info.pty_id, owned_cwd) catch {
                             state.allocator.free(owned_cwd);
@@ -350,7 +355,7 @@ pub const ClientLogic = struct {
         if (id >= 0) {
             state.pty_id = id;
             state.attached = true;
-            if (cwd) |c| {
+            if (nonEmptyCwd(cwd)) |c| {
                 const owned_cwd = state.allocator.dupe(u8, c) catch return .{ .attached = .{ .new_pty_id = id, .old_pty_id = old_pty_id } };
                 state.cwd_map.put(id, owned_cwd) catch {
                     state.allocator.free(owned_cwd);
@@ -506,6 +511,13 @@ pub const ClientLogic = struct {
 
         const cwd = if (cwd_val) |v| (if (v == .string) v.string else null) else return .none;
         const cwd_str = cwd orelse return .none;
+
+        if (cwd_str.len == 0) {
+            if (state.cwd_map.fetchRemove(pty_id)) |entry| {
+                state.allocator.free(entry.value);
+            }
+            return .{ .cwd_changed = .{ .pty_id = @intCast(pty_id), .cwd = cwd_str } };
+        }
 
         if (state.cwd_map.getPtr(pty_id)) |entry| {
             state.allocator.free(entry.*);
@@ -1879,10 +1891,11 @@ pub const App = struct {
 
     fn spawnInitialPty(self: *App) !void {
         const ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const initial_cwd = nonEmptyCwd(self.initial_cwd);
 
         const msgid = self.state.next_msgid;
         self.state.next_msgid += 1;
-        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = self.initial_cwd } });
+        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = initial_cwd } });
 
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();
@@ -1900,16 +1913,16 @@ pub const App = struct {
         }
 
         const macos_option_as_alt = self.ui.getMacosOptionAsAlt();
-        const param_count: usize = if (self.initial_cwd != null) 6 else 5;
+        const param_count: usize = if (initial_cwd != null) 6 else 5;
         var params_kv = try self.allocator.alloc(msgpack.Value.KeyValue, param_count);
         defer self.allocator.free(params_kv);
-        log.info("Sending spawn_pty: rows={} cols={} cwd={?s} env_count={}", .{ ws.rows, ws.cols, self.initial_cwd, env_array.items.len });
+        log.info("Sending spawn_pty: rows={} cols={} cwd={?s} env_count={}", .{ ws.rows, ws.cols, initial_cwd, env_array.items.len });
         params_kv[0] = .{ .key = .{ .string = "rows" }, .value = .{ .unsigned = ws.rows } };
         params_kv[1] = .{ .key = .{ .string = "cols" }, .value = .{ .unsigned = ws.cols } };
         params_kv[2] = .{ .key = .{ .string = "attach" }, .value = .{ .boolean = true } };
         params_kv[3] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
         params_kv[4] = .{ .key = .{ .string = "macos_option_as_alt" }, .value = .{ .string = macos_option_as_alt } };
-        if (self.initial_cwd) |cwd| {
+        if (initial_cwd) |cwd| {
             params_kv[5] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = cwd } };
         }
         const params_val = msgpack.Value{ .map = params_kv };
@@ -1967,7 +1980,7 @@ pub const App = struct {
         self.pending_attach_count = pty_ids.len;
 
         for (pty_ids) |pty_id| {
-            const cwd = self.pending_attach_cwd.get(pty_id);
+            const cwd = nonEmptyCwd(self.pending_attach_cwd.get(pty_id));
 
             // If validity doesn't match, spawn fresh instead of attaching
             if (!validity_matches) {
@@ -2016,6 +2029,7 @@ pub const App = struct {
 
     fn spawnPtyWithCwd(self: *App, msgid: u32, cwd: ?[]const u8) !void {
         const ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const resolved_cwd = nonEmptyCwd(cwd);
 
         var env_map = try std.process.getEnvMap(self.allocator);
         defer env_map.deinit();
@@ -2029,7 +2043,7 @@ pub const App = struct {
         }
 
         const macos_option_as_alt = self.ui.getMacosOptionAsAlt();
-        const param_count: usize = if (cwd != null) 6 else 5;
+        const param_count: usize = if (resolved_cwd != null) 6 else 5;
         var params_kv = try self.allocator.alloc(msgpack.Value.KeyValue, param_count);
         defer self.allocator.free(params_kv);
         params_kv[0] = .{ .key = .{ .string = "rows" }, .value = .{ .unsigned = ws.rows } };
@@ -2037,7 +2051,7 @@ pub const App = struct {
         params_kv[2] = .{ .key = .{ .string = "attach" }, .value = .{ .boolean = true } };
         params_kv[3] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
         params_kv[4] = .{ .key = .{ .string = "macos_option_as_alt" }, .value = .{ .string = macos_option_as_alt } };
-        if (cwd) |c| {
+        if (resolved_cwd) |c| {
             params_kv[5] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = c } };
         }
         const params_val = msgpack.Value{ .map = params_kv };
@@ -2368,10 +2382,11 @@ pub const App = struct {
                                 }
                             },
                             .spawn_pty_with_cwd => |info| {
-                                log.info("Spawning new PTY with cwd: {s}", .{if (info.cwd) |c| c else "default"});
+                                const cwd = nonEmptyCwd(info.cwd);
+                                log.info("Spawning new PTY with cwd: {s}", .{if (cwd) |c| c else "default"});
                                 const msgid = app.state.next_msgid;
                                 app.state.next_msgid += 1;
-                                try app.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = info.cwd } });
+                                try app.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = cwd } });
 
                                 // Build env array from current process environment
                                 var env_map = try std.process.getEnvMap(app.allocator);
@@ -2386,14 +2401,12 @@ pub const App = struct {
                                 }
 
                                 // Build spawn_pty params with env and optional cwd
-                                const param_count: usize = if (info.cwd != null) 2 else 1;
+                                const param_count: usize = if (cwd != null) 2 else 1;
                                 var kv = try app.allocator.alloc(msgpack.Value.KeyValue, param_count);
                                 defer app.allocator.free(kv);
                                 kv[0] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
-                                if (info.cwd) |cwd| {
-                                    if (cwd.len > 0) {
-                                        kv[1] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = cwd } };
-                                    }
+                                if (cwd) |resolved_cwd| {
+                                    kv[1] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = resolved_cwd } };
                                 }
 
                                 var arr = try app.allocator.alloc(msgpack.Value, 4);
@@ -2559,9 +2572,10 @@ pub const App = struct {
     pub fn spawnPty(self: *App, opts: UI.SpawnOptions) !void {
         const msgid = self.state.next_msgid;
         self.state.next_msgid += 1;
+        const cwd = nonEmptyCwd(opts.cwd);
 
         log.info("spawnPty: sending request msgid={}", .{msgid});
-        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = opts.cwd } });
+        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = cwd } });
 
         // Build env array from current process environment
         var env_map = try std.process.getEnvMap(self.allocator);
@@ -2575,7 +2589,7 @@ pub const App = struct {
             try env_array.append(self.allocator, .{ .string = env_str });
         }
 
-        const num_params: usize = if (opts.cwd != null) 5 else 4;
+        const num_params: usize = if (cwd != null) 5 else 4;
         var map_items = try self.allocator.alloc(msgpack.Value.KeyValue, num_params);
         defer self.allocator.free(map_items);
 
@@ -2583,8 +2597,8 @@ pub const App = struct {
         map_items[1] = .{ .key = .{ .string = "cols" }, .value = .{ .unsigned = opts.cols } };
         map_items[2] = .{ .key = .{ .string = "attach" }, .value = .{ .boolean = opts.attach } };
         map_items[3] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
-        if (opts.cwd) |cwd| {
-            map_items[4] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = cwd } };
+        if (cwd) |resolved_cwd| {
+            map_items[4] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = resolved_cwd } };
         }
 
         const params = msgpack.Value{ .map = map_items };
@@ -2989,13 +3003,11 @@ pub const App = struct {
                         if (obj.get("pty_id")) |pty_id_val| {
                             if (pty_id_val == .integer) {
                                 const pty_id: u32 = @intCast(pty_id_val.integer);
-                                var cwd: ?[]const u8 = null;
                                 if (obj.get("cwd")) |cwd_val| {
-                                    if (cwd_val == .string) {
-                                        cwd = try allocator.dupe(u8, cwd_val.string);
+                                    if (cwd_val == .string and cwd_val.string.len > 0) {
+                                        try pairs.put(pty_id, try allocator.dupe(u8, cwd_val.string));
                                     }
                                 }
-                                try pairs.put(pty_id, cwd orelse try allocator.dupe(u8, ""));
                             }
                         }
                     }
@@ -3458,6 +3470,36 @@ test "ClientLogic - shouldFlush" {
 
         try testing.expect(!ClientLogic.shouldFlush(params));
     }
+}
+
+test "extractPtyIdCwdPairs skips missing and empty cwd" {
+    const testing = std.testing;
+
+    const json =
+        \\{
+        \\  "root": {
+        \\    "type": "split",
+        \\    "children": [
+        \\      { "type": "pane", "id": 1, "pty_id": 1, "cwd": "/tmp/project" },
+        \\      { "type": "pane", "id": 2, "pty_id": 2, "cwd": "" },
+        \\      { "type": "pane", "id": 3, "pty_id": 3 }
+        \\    ]
+        \\  }
+        \\}
+    ;
+
+    var pairs = try App.extractPtyIdCwdPairs(testing.allocator, json);
+    defer {
+        var it = pairs.valueIterator();
+        while (it.next()) |cwd| {
+            testing.allocator.free(cwd.*);
+        }
+        pairs.deinit();
+    }
+
+    try testing.expectEqualStrings("/tmp/project", pairs.get(1).?);
+    try testing.expect(!pairs.contains(2));
+    try testing.expect(!pairs.contains(3));
 }
 
 test "UnixSocketClient - successful connection" {

--- a/src/client.zig
+++ b/src/client.zig
@@ -179,11 +179,13 @@ pub const ClientState = struct {
     allocator: std.mem.Allocator,
     prefix_mode: bool = false,
     pty_validity: ?i64 = null,
+    suppress_unsolicited_pty_results: bool = false,
 
     pub const RequestInfo = union(enum) {
         spawn: struct { cwd: ?[]const u8 = null, old_pty_id: ?u32 = null },
         attach: struct { pty_id: i64, cwd: ?[]const u8 = null },
         detach,
+        switch_detach,
         get_server_info,
         copy_selection,
     };
@@ -215,6 +217,8 @@ pub const ServerAction = union(enum) {
     pty_exited: struct { pty_id: u32, status: u32 },
     cwd_changed: struct { pty_id: u32, cwd: []const u8 },
     detached,
+    switch_detached,
+    switch_detach_failed,
     color_query: ColorQueryTarget,
     server_info: struct { pty_validity: i64 },
     copy_to_clipboard: []const u8,
@@ -271,6 +275,9 @@ pub const ClientLogic = struct {
                     log.info("PTY {} not found, spawning new PTY with cwd", .{attach_info.pty_id});
                     return .{ .spawn_pty_with_cwd = .{ .cwd = attach_info.cwd } };
                 }
+            } else if (entry.value == .switch_detach) {
+                log.err("Session switch detach failed: {}", .{err_val});
+                return .switch_detach_failed;
             }
         }
         log.err("Error in response: {}", .{err_val});
@@ -294,6 +301,7 @@ pub const ClientLogic = struct {
                     return .{ .attached = .{ .new_pty_id = attach_info.pty_id } };
                 },
                 .detach => .detached,
+                .switch_detach => .switch_detached,
                 .get_server_info => handleServerInfoResult(state, result),
                 .copy_selection => handleCopySelectionResult(result),
             };
@@ -356,6 +364,9 @@ pub const ClientLogic = struct {
     fn handleUnsolicitedResult(state: *ClientState, result: msgpack.Value) ServerAction {
         return switch (result) {
             .integer => |i| {
+                if (state.suppress_unsolicited_pty_results) {
+                    return .none;
+                }
                 if (state.pty_id == null) {
                     state.pty_id = i;
                     return .{ .send_attach = i };
@@ -366,6 +377,9 @@ pub const ClientLogic = struct {
                 return .none;
             },
             .unsigned => |u| {
+                if (state.suppress_unsolicited_pty_results) {
+                    return .none;
+                }
                 if (state.pty_id == null) {
                     state.pty_id = @intCast(u);
                     state.attached = true;
@@ -663,6 +677,8 @@ pub const App = struct {
 
     // Current session name (owned by App)
     current_session_name: ?[]const u8 = null,
+    switch_target_session: ?[]const u8 = null,
+    session_switch_in_progress: bool = false,
     // Auto-save timer for debouncing
     autosave_timer: ?io.Task = null,
 
@@ -803,6 +819,9 @@ pub const App = struct {
         if (self.current_session_name) |name| {
             self.allocator.free(name);
         }
+        if (self.switch_target_session) |target| {
+            self.allocator.free(target);
+        }
         if (self.hit_regions.len > 0) self.allocator.free(self.hit_regions);
         if (self.split_handles.len > 0) self.allocator.free(self.split_handles);
         self.vx.deinit(self.allocator, self.tty.writer());
@@ -903,38 +922,9 @@ pub const App = struct {
             fn detachCb(ctx: *anyopaque, session_name: []const u8) anyerror!void {
                 const app_ptr: *App = @ptrCast(@alignCast(ctx));
                 try app_ptr.saveSession(session_name);
-
-                // Build array of PTY IDs to detach
-                var pty_ids = try app_ptr.allocator.alloc(msgpack.Value, app_ptr.surfaces.count());
-                defer app_ptr.allocator.free(pty_ids);
-                var i: usize = 0;
-                var key_iter = app_ptr.surfaces.keyIterator();
-                while (key_iter.next()) |pty_id| {
-                    pty_ids[i] = .{ .unsigned = pty_id.* };
-                    i += 1;
-                }
-
-                // Send single detach_session request with all PTY IDs
-                const msgid = app_ptr.state.next_msgid;
-                app_ptr.state.next_msgid +%= 1;
-
-                var arr = try app_ptr.allocator.alloc(msgpack.Value, 4);
-                arr[0] = .{ .unsigned = 0 }; // request
-                arr[1] = .{ .unsigned = msgid };
-                arr[2] = .{ .string = "detach_ptys" };
-                arr[3] = .{ .array = pty_ids };
-
-                const encoded = msgpack.encodeFromValue(app_ptr.allocator, msgpack.Value{ .array = arr }) catch {
-                    app_ptr.allocator.free(arr);
+                if (!try app_ptr.sendDetachPtysRequest(.detach)) {
                     return;
-                };
-                defer app_ptr.allocator.free(encoded);
-                app_ptr.allocator.free(arr);
-
-                // Track that we're waiting for detach response
-                try app_ptr.state.pending_requests.put(msgid, .detach);
-
-                app_ptr.sendDirect(encoded) catch {};
+                }
             }
         }.detachCb);
 
@@ -1122,6 +1112,13 @@ pub const App = struct {
                 }
             }
             return;
+        }
+
+        if (self.session_switch_in_progress) {
+            switch (event) {
+                .key_press, .key_release, .mouse => return,
+                else => {},
+            }
         }
 
         // Handle mouse events specially - do hit testing and convert to MouseEvent
@@ -1716,16 +1713,160 @@ pub const App = struct {
         self.allocator.free(msg);
     }
 
+    fn setCurrentSessionName(self: *App, session_name: []const u8) !void {
+        if (self.current_session_name) |current| {
+            self.allocator.free(current);
+        }
+        self.current_session_name = try self.allocator.dupe(u8, session_name);
+    }
+
+    fn clearCwdMap(self: *App) void {
+        var cwd_it = self.state.cwd_map.valueIterator();
+        while (cwd_it.next()) |cwd| {
+            self.allocator.free(cwd.*);
+        }
+        self.state.cwd_map.clearRetainingCapacity();
+    }
+
+    fn clearPendingAttachState(self: *App) void {
+        if (self.pending_attach_ids) |ids| {
+            self.allocator.free(ids);
+            self.pending_attach_ids = null;
+        }
+        if (self.session_json) |json| {
+            self.allocator.free(json);
+            self.session_json = null;
+        }
+        var cwd_it = self.pending_attach_cwd.valueIterator();
+        while (cwd_it.next()) |cwd| {
+            self.allocator.free(cwd.*);
+        }
+        self.pending_attach_cwd.clearRetainingCapacity();
+        self.pending_attach_count = 0;
+        self.pty_id_remap.clearRetainingCapacity();
+    }
+
+    fn sendDetachPtysRequest(self: *App, request_info: ClientState.RequestInfo) !bool {
+        if (self.surfaces.count() == 0) {
+            return false;
+        }
+
+        var pty_ids = try self.allocator.alloc(msgpack.Value, self.surfaces.count());
+        defer self.allocator.free(pty_ids);
+
+        var i: usize = 0;
+        var key_iter = self.surfaces.keyIterator();
+        while (key_iter.next()) |pty_id| {
+            pty_ids[i] = .{ .unsigned = pty_id.* };
+            i += 1;
+        }
+
+        const msgid = self.state.next_msgid;
+        self.state.next_msgid +%= 1;
+        try self.state.pending_requests.put(msgid, request_info);
+        errdefer _ = self.state.pending_requests.remove(msgid);
+
+        var arr = try self.allocator.alloc(msgpack.Value, 4);
+        defer self.allocator.free(arr);
+        arr[0] = .{ .unsigned = 0 };
+        arr[1] = .{ .unsigned = msgid };
+        arr[2] = .{ .string = "detach_ptys" };
+        arr[3] = .{ .array = pty_ids };
+
+        const encoded = try msgpack.encodeFromValue(self.allocator, msgpack.Value{ .array = arr });
+        defer self.allocator.free(encoded);
+
+        try self.sendDirect(encoded);
+        return true;
+    }
+
+    fn resetActiveSessionState(self: *App) !void {
+        if (self.render_timer) |*task| {
+            if (self.io_loop) |loop| {
+                task.cancel(loop) catch {};
+            }
+            self.render_timer = null;
+        }
+        if (self.autosave_timer) |*task| {
+            if (self.io_loop) |loop| {
+                task.cancel(loop) catch {};
+            }
+            self.autosave_timer = null;
+        }
+        if (self.paste_buffer) |*buf| {
+            buf.deinit(self.allocator);
+            self.paste_buffer = null;
+        }
+
+        var surface_it = self.surfaces.valueIterator();
+        while (surface_it.next()) |surface| {
+            surface.*.deinit();
+            self.allocator.destroy(surface.*);
+        }
+        self.surfaces.clearRetainingCapacity();
+
+        self.drag_state = null;
+        self.selection_drag_pty = null;
+        self.state.pty_id = null;
+        self.state.response_received = false;
+        self.state.attached = false;
+        self.state.connection_refused = false;
+        self.state.prefix_mode = false;
+        self.state.suppress_unsolicited_pty_results = true;
+        self.state.pending_requests.clearRetainingCapacity();
+        self.clearCwdMap();
+        self.clearPendingAttachState();
+        self.pending_color_queries.clearRetainingCapacity();
+
+        if (self.hit_regions.len > 0) {
+            self.allocator.free(self.hit_regions);
+            self.hit_regions = &.{};
+        }
+        if (self.split_handles.len > 0) {
+            self.allocator.free(self.split_handles);
+            self.split_handles = &.{};
+        }
+
+        try self.ui.clearState();
+    }
+
+    fn cancelSessionSwitch(self: *App) void {
+        self.session_switch_in_progress = false;
+        self.state.suppress_unsolicited_pty_results = false;
+        if (self.switch_target_session) |target| {
+            self.allocator.free(target);
+            self.switch_target_session = null;
+        }
+    }
+
+    fn completeSessionSwitch(self: *App) void {
+        self.session_switch_in_progress = false;
+        self.state.suppress_unsolicited_pty_results = false;
+        if (self.switch_target_session) |target| {
+            self.allocator.free(target);
+            self.switch_target_session = null;
+        }
+    }
+
+    fn beginSessionSwitchAttach(self: *App) !void {
+        const target_session = self.switch_target_session orelse return error.NoSessionSwitchTarget;
+        errdefer self.cancelSessionSwitch();
+
+        try self.resetActiveSessionState();
+        try self.startSessionAttach(target_session);
+        try self.setCurrentSessionName(target_session);
+    }
+
     fn onServerInfoReceived(self: *App) !void {
         // After receiving server info, proceed with spawn or session attach
         if (self.attach_session) |session_name| {
             // Use the attached session name
             log.info("Setting current_session_name to: {s}", .{session_name});
-            self.current_session_name = try self.allocator.dupe(u8, session_name);
+            try self.setCurrentSessionName(session_name);
             try self.startSessionAttach(session_name);
         } else if (self.new_session_name) |name| {
             // User specified a name for new session
-            self.current_session_name = try self.allocator.dupe(u8, name);
+            try self.setCurrentSessionName(name);
             log.info("Starting new session with user-specified name: {s}", .{name});
             try self.spawnInitialPty();
         } else {
@@ -1778,6 +1919,8 @@ pub const App = struct {
     }
 
     fn startSessionAttach(self: *App, session_name: []const u8) !void {
+        self.clearPendingAttachState();
+
         const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
 
         const filename = try std.fmt.allocPrint(self.allocator, "{s}.json", .{session_name});
@@ -2215,6 +2358,10 @@ pub const App = struct {
                                                 app.allocator.free(ids);
                                                 app.pending_attach_ids = null;
                                             }
+                                            app.state.suppress_unsolicited_pty_results = false;
+                                            if (app.session_switch_in_progress) {
+                                                app.completeSessionSwitch();
+                                            }
                                             try app.scheduleRender();
                                         }
                                     }
@@ -2265,16 +2412,17 @@ pub const App = struct {
                                 log.info("PTY {} exited with status {}", .{ info.pty_id, info.status });
                                 // Clean up the surface for this PTY BEFORE updating UI
                                 // so that surfaces.count() is correct when quit callback runs
-                                if (app.surfaces.fetchRemove(info.pty_id)) |entry| {
+                                const removed_surface = if (app.surfaces.fetchRemove(info.pty_id)) |entry| blk: {
                                     log.info("Cleaning up surface for exited PTY {}", .{info.pty_id});
                                     entry.value.deinit();
                                     app.allocator.destroy(entry.value);
-                                }
+                                    break :blk true;
+                                } else false;
                                 app.ui.update(.{ .pty_exited = .{ .id = info.pty_id, .status = info.status } }) catch |err| {
                                     log.err("Failed to update UI with pty_exited: {}", .{err});
                                 };
                                 // Delete session file when last PTY exits (if quit wasn't already called)
-                                if (app.surfaces.count() == 0 and !app.state.should_quit) {
+                                if (removed_surface and app.surfaces.count() == 0 and !app.state.should_quit) {
                                     // Cancel autosave timer to prevent it from recreating the file
                                     if (app.autosave_timer) |*task| {
                                         if (app.io_loop) |loop| task.cancel(loop) catch {};
@@ -2335,6 +2483,12 @@ pub const App = struct {
                                 app.vx.deviceStatusReport(app.tty.writer()) catch {};
                                 log.info("Returning from detach handler", .{});
                                 return;
+                            },
+                            .switch_detached => {
+                                try app.beginSessionSwitchAttach();
+                            },
+                            .switch_detach_failed => {
+                                app.cancelSessionSwitch();
                             },
                             .color_query => |query| {
                                 try app.handleColorQuery(query);
@@ -2616,6 +2770,9 @@ pub const App = struct {
                 return;
             }
         }
+        if (self.session_switch_in_progress) {
+            return error.SessionSwitchInProgress;
+        }
 
         // Save current session first
         if (self.current_session_name) |name| {
@@ -2623,32 +2780,20 @@ pub const App = struct {
             try self.saveSession(name);
         }
 
-        // Build arguments for exec
-        // Build arguments for exec
-        const target_z = try self.allocator.dupeZ(u8, target_session);
-        errdefer self.allocator.free(target_z);
-        const args = [_]?[*:0]const u8{
-            "prise",
-            "session",
-            "attach",
-            target_z,
-            null,
-        };
+        self.switch_target_session = try self.allocator.dupe(u8, target_session);
+        errdefer {
+            if (self.switch_target_session) |target| {
+                self.allocator.free(target);
+                self.switch_target_session = null;
+            }
+        }
 
-        log.info("Exec'ing prise session attach '{s}'", .{target_session});
+        self.session_switch_in_progress = true;
+        errdefer self.session_switch_in_progress = false;
 
-        // Restore terminal state right before exec to minimize window of failure
-        const writer = self.tty.writer();
-        self.vx.deinit(self.allocator, writer);
-
-        // Use execvpeZ with current environment
-        const err = posix.execvpeZ("prise", @ptrCast(&args), @ptrCast(std.c.environ));
-
-        // If we get here, exec failed - reinitialize terminal
-        log.err("Failed to exec prise: {}", .{err});
-        self.vx = vaxis.Vaxis.init(self.allocator, .{}) catch return err;
-        self.vx.enterAltScreen(writer) catch {};
-        return err;
+        if (!try self.sendDetachPtysRequest(.switch_detach)) {
+            try self.beginSessionSwitchAttach();
+        }
     }
 
     pub fn deleteCurrentSession(self: *App) void {
@@ -3143,6 +3288,24 @@ test "ClientLogic - processServerMessage" {
         try testing.expectEqual(123, action.attached.new_pty_id);
     }
 
+    // Test switch detach response
+    {
+        var state = ClientState.init(testing.allocator);
+        defer state.deinit();
+        try state.pending_requests.put(3, .switch_detach);
+
+        const msg = rpc.Message{
+            .response = .{
+                .msgid = 3,
+                .err = null,
+                .result = .nil,
+            },
+        };
+
+        const action = try ClientLogic.processServerMessage(&state, msg);
+        try testing.expectEqual(std.meta.Tag(ServerAction).switch_detached, std.meta.activeTag(action));
+    }
+
     // Test Redraw Notification
     {
         var state = ClientState.init(testing.allocator);
@@ -3158,6 +3321,25 @@ test "ClientLogic - processServerMessage" {
 
         const action = try ClientLogic.processServerMessage(&state, msg);
         try testing.expectEqual(std.meta.Tag(ServerAction).redraw, std.meta.activeTag(action));
+    }
+
+    // Test unsolicited PTY results can be suppressed during session switch
+    {
+        var state = ClientState.init(testing.allocator);
+        defer state.deinit();
+        state.suppress_unsolicited_pty_results = true;
+
+        const msg = rpc.Message{
+            .response = .{
+                .msgid = 99,
+                .err = null,
+                .result = .{ .integer = 456 },
+            },
+        };
+
+        const action = try ClientLogic.processServerMessage(&state, msg);
+        try testing.expectEqual(std.meta.Tag(ServerAction).none, std.meta.activeTag(action));
+        try testing.expectEqual(null, state.pty_id);
     }
 }
 

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -455,6 +455,63 @@ local state = {
     pending_layout = nil,
 }
 
+local function reset_session_state()
+    if state.timer then
+        state.timer:cancel()
+        state.timer = nil
+    end
+
+    state.tabs = {}
+    state.active_tab = 1
+    state.next_tab_id = 1
+    state.focused_id = nil
+    state.zoomed_pane_id = nil
+    state.pending_command = false
+    state.pending_split = nil
+    state.pending_new_tab = false
+    state.next_split_id = 1
+
+    state.palette.visible = false
+    state.palette.selected = 1
+    state.palette.scroll_offset = 0
+    state.palette.regions = {}
+    if state.palette.input then
+        state.palette.input:clear()
+    end
+
+    state.rename.visible = false
+    if state.rename.input then
+        state.rename.input:clear()
+    end
+
+    state.rename_tab.visible = false
+    if state.rename_tab.input then
+        state.rename_tab.input:clear()
+    end
+
+    state.swap_with_index = nil
+
+    state.session_picker.visible = false
+    state.session_picker.selected = 1
+    state.session_picker.scroll_offset = 0
+    state.session_picker.sessions = {}
+    state.session_picker.regions = {}
+    state.session_picker.renaming = false
+    state.session_picker.rename_target = nil
+    if state.session_picker.input then
+        state.session_picker.input:clear()
+    end
+
+    state.tab_regions = {}
+    state.tab_close_regions = {}
+    state.hovered_tab = nil
+    state.hovered_close_tab = nil
+    state.cached_git_branch = nil
+    state.detaching = false
+    state.floating.pending = false
+    state.floating.resize_mode = false
+end
+
 local M = {}
 
 ---Forward declaration for action_handlers (defined after helper functions)
@@ -4329,6 +4386,8 @@ end
 ---@param saved? table
 ---@param pty_lookup fun(id: number): Pty?
 function M.set_state(saved, pty_lookup)
+    reset_session_state()
+
     if not saved then
         return
     end
@@ -4397,6 +4456,7 @@ function M.set_state(saved, pty_lookup)
         end
     end
 
+    update_cached_git_branch()
     prise.request_frame()
 end
 

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -550,6 +550,13 @@ local RESIZE_STEP = 0.05 -- 5% step for keyboard resize
 local PALETTE_WIDTH = 60 -- Total width of command palette
 local PALETTE_INNER_WIDTH = 56 -- Inner width (PALETTE_WIDTH - 4 for padding)
 
+---@return integer start_x
+---@return integer end_x
+local function modal_x_bounds()
+    local start_x = math.floor((state.screen_cols - PALETTE_WIDTH) / 2)
+    return start_x, start_x + PALETTE_WIDTH
+end
+
 -- Floating pane size bounds
 local FLOATING_MIN_WIDTH = 40
 local FLOATING_MAX_WIDTH = 200
@@ -1503,8 +1510,11 @@ end
 local function build_tabs_from_layout(layout, pty_queue)
     local new_tabs = {}
     local queue_idx = 1
+    ---@type number
     local new_floating_width = state.floating.width
+    ---@type number
     local new_floating_height = state.floating.height
+    ---@type boolean
     local new_floating_visible = state.floating.visible
 
     for tab_index, tab_def in ipairs(layout.tabs) do
@@ -1564,6 +1574,12 @@ local function finalize_layout(pending)
         state.pending_layout = nil
         return
     end
+    local floating_width = new_floating_width or state.floating.width
+    local floating_height = new_floating_height or state.floating.height
+    local floating_visible = new_floating_visible
+    if floating_visible == nil then
+        floating_visible = state.floating.visible
+    end
 
     -- Verify we used all PTYs
     if queue_idx ~= #pty_queue + 1 then
@@ -1579,9 +1595,9 @@ local function finalize_layout(pending)
     -- Swap in new state
     state.tabs = new_tabs
     state.next_tab_id = #new_tabs + 1
-    state.floating.width = new_floating_width
-    state.floating.height = new_floating_height
-    state.floating.visible = new_floating_visible
+    state.floating.width = floating_width
+    state.floating.height = floating_height
+    state.floating.visible = floating_visible
     state.zoomed_pane_id = nil
 
     -- Set active tab
@@ -1635,7 +1651,7 @@ local function expand_path(path)
         return expanded
     end
 
-    -- Check if it's a directory without using shell (avoids command injection)
+    -- Probe "path/." so we can recognize directories without shelling out.
     local dir_probe = io.open(expanded .. "/.", "r")
     if dir_probe then
         dir_probe:close()
@@ -3217,14 +3233,59 @@ function M.update(event)
         end
 
         if d.action == "press" and d.button == "left" then
+            -- Check if click is on session picker item
+            if
+                state.session_picker.visible
+                and not state.session_picker.renaming
+                and #state.session_picker.regions > 0
+            then
+                local click_x = math.floor(d.x)
+                local click_y = math.floor(d.y)
+                local modal_start_x, modal_end_x = modal_x_bounds()
+
+                if click_x >= modal_start_x and click_x < modal_end_x then
+                    for _, region in ipairs(state.session_picker.regions) do
+                        if click_y >= region.start_y and click_y < region.end_y then
+                            if state.session_picker.selected == region.index then
+                                execute_session_switch()
+                            else
+                                state.session_picker.selected = region.index
+                                prise.request_frame()
+                            end
+                            return
+                        end
+                    end
+                end
+            end
+
+            -- Check if click is on layout picker item
+            if state.layout_picker.visible and #state.layout_picker.regions > 0 then
+                local click_x = math.floor(d.x)
+                local click_y = math.floor(d.y)
+                local modal_start_x, modal_end_x = modal_x_bounds()
+
+                if click_x >= modal_start_x and click_x < modal_end_x then
+                    for _, region in ipairs(state.layout_picker.regions) do
+                        if click_y >= region.start_y and click_y < region.end_y then
+                            if state.layout_picker.selected == region.index then
+                                execute_selected_layout()
+                            else
+                                state.layout_picker.selected = region.index
+                                prise.request_frame()
+                            end
+                            return
+                        end
+                    end
+                end
+            end
+
             -- Check if click is on command palette item
             if state.palette.visible and #state.palette.regions > 0 then
                 -- Convert float coords to integer cell positions
                 local click_x = math.floor(d.x)
                 local click_y = math.floor(d.y)
 
-                local palette_start_x = math.floor((state.screen_cols - PALETTE_WIDTH) / 2)
-                local palette_end_x = palette_start_x + PALETTE_WIDTH
+                local palette_start_x, palette_end_x = modal_x_bounds()
 
                 if click_x >= palette_start_x and click_x < palette_end_x then
                     for _, region in ipairs(state.palette.regions) do

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -1155,6 +1155,26 @@ pub const UI = struct {
         self.allocator.destroy(lookup_ctx);
     }
 
+    pub fn clearState(self: *UI) !void {
+        _ = self.lua.getField(ziglua.registry_index, "prise_ui");
+        defer self.lua.pop(1);
+
+        _ = self.lua.getField(-1, "set_state");
+        if (self.lua.typeOf(-1) != .function) {
+            return error.NoSetStateFunction;
+        }
+
+        self.lua.pushNil();
+        self.lua.pushNil();
+
+        self.lua.protectedCall(.{ .args = 2, .results = 0, .msg_handler = 0 }) catch |err| {
+            const msg = self.lua.toString(-1) catch "Unknown Lua error";
+            log.err("Lua clear_state error: {s}", .{msg});
+            self.lua.pop(1);
+            return err;
+        };
+    }
+
     fn ptyLookupWrapper(lua: *ziglua.Lua) i32 {
         const LookupCtx = struct {
             ctx: *anyopaque,


### PR DESCRIPTION
Due to an extreme level of smoothness I'm going to call it now: It's not impossible that this is not butter. Too smooth. Dangerously smooth. Smoothness level hurts. Let's go!

Seriously though, if this doesn't make you puke in your mouth (even if it's just a butter induced gag reflex) let me know if you want any changes or squashing to happen. <3

---

## What's in here

### Session switching without exec
Replaces the old `execvpeZ("prise", ...)` approach with an in-process detach → reset → reattach flow. No more terminal flicker, no exec failure recovery path, no re-initialization dance. Input is blocked during the switch window, and stale PTY IDs are suppressed until the new session is fully attached.

### Empty CWD normalization
Normalizes empty cwd values to null before storing, persisting, or replaying PTY state. Fixes a bug where session restore sent an empty cwd string back to the server on fallback spawn, causing `chdir("")` to fail during session switches.

### Review follow-ups
- Collapsed duplicate `cancelSessionSwitch`/`completeSessionSwitch` into shared `finishSessionSwitch()`
- Wired mouse click handling for both the session picker (pre-existing gap) and the layout picker
- Added comment clarifying the shell-free directory probe in `expand_path`
- Normalized floating-state fallbacks for clean Lua language-server typecheck