### PR TITLE
expose execute_action in tiling ui

### DIFF
--- a/docs/prise.5.md
+++ b/docs/prise.5.md
@@ -498,6 +498,24 @@ The tiling UI uses a leader key sequence. Press the leader key (default:
 
 The command palette (**Super+p**) provides fuzzy search for all commands.
 
+# TILING UI HELPERS
+
+The built-in tiling UI also exposes helper methods that user configuration code
+can call directly.
+
+**ui.execute_action(name)**
+:   Execute a built-in action by its string name. This is useful when custom
+    Lua code needs to trigger the same action handlers used by keybinds and the
+    command palette.
+
+Example:
+
+```lua
+local ui = require("prise").tiling()
+
+ui.execute_action("close_tab")
+```
+
 # SEE ALSO
 
 [prise(1)](prise.1.html), [prise(7)](prise.7.html)

--- a/docs/prise.7.md
+++ b/docs/prise.7.md
@@ -143,6 +143,11 @@ A custom UI must return a table with:
 - **get_state(cwd_lookup)**: Serialize state for persistence (optional)
 - **set_state(saved, pty_lookup)**: Restore state (optional)
 
+Custom UIs may also expose optional helpers used by configuration code:
+
+- **execute_action(name)**: Run a built-in action handler by name
+- **setup(opts)**: Apply UI-specific configuration before the UI is returned
+
 # SEE ALSO
 
 [prise(1)](prise.1.html), [prise(5)](prise.5.html)

--- a/src/lua/prise.lua
+++ b/src/lua/prise.lua
@@ -64,6 +64,8 @@
 ---@field get_state? fun(cwd_lookup: fun(id: number): string?): table Serialize UI state for persistence
 ---@field set_state? fun(saved: table?, pty_lookup: fun(id: number): Pty?) Restore UI state
 ---@field setup? fun(opts: table?) Configure the UI (optional)
+---@field get_macos_option_as_alt? fun(): boolean Return whether macOS Option should act as Alt
+---@field execute_action? fun(name: string) Execute a built-in action by name
 
 local M = {}
 

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -4400,6 +4400,18 @@ function M.set_state(saved, pty_lookup)
     prise.request_frame()
 end
 
+---Execute a built-in action by name.
+---This allows user config code to programmatically trigger actions
+---(e.g. from dialog callbacks) without direct access to action_handlers.
+---@param name string Action name (e.g. "close_pane", "close_tab")
+function M.execute_action(name)
+    local handler = action_handlers[name]
+    if handler then
+        handler()
+        prise.request_frame()
+    end
+end
+
 -- Export internal functions for testing
 M._test = {
     is_pane = is_pane,

--- a/src/lua/types/prise.lua
+++ b/src/lua/types/prise.lua
@@ -19,6 +19,15 @@
 ---@field keybind KeybindModule Keybind compilation and matching
 local prise = {}
 
+---@class PriseUI
+---@field update fun(event: table) Handle an input event
+---@field view fun(): table Return the widget tree to render
+---@field get_state? fun(cwd_lookup: fun(id: number): string?): table Serialize UI state for persistence
+---@field set_state? fun(saved: table?, pty_lookup: fun(id: number): Pty?) Restore UI state
+---@field setup? fun(opts: table?) Configure the UI (optional)
+---@field get_macos_option_as_alt? fun(): boolean Return whether macOS Option should act as Alt
+---@field execute_action fun(name: string) Execute a built-in action by name
+
 ---Load the tiling UI module
 ---@return PriseUI
 function prise.tiling() end


### PR DESCRIPTION
lets user config code trigger built-in actions programmatically — e.g. firing "close_pane" from a dialog callback without reaching into action_handlers directly.

LET MIKEY DO THIS:
<img width="1255" height="684" alt="image" src="https://github.com/user-attachments/assets/e2b82fb8-d4dc-4d3c-ae56-c6d32ceb850b" />