### PR TITLE
Switch sessions in-process without exec

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -1783,22 +1783,9 @@ pub const App = struct {
         return session_name orelse "(none)";
     }
 
-    fn updateSessionSwitchState(self: *App, active: bool) !void {
-        const target_session = if (self.preparedRestoreSessionName()) |name| name else "";
-        try self.ui.update(.{
-            .session_switch = .{
-                .active = active,
-                .target_session = target_session,
-            },
-        });
-    }
-
     fn finishSessionSwitch(self: *App) void {
         self.session_switch_in_progress = false;
         self.state.suppress_unsolicited_pty_results = false;
-        self.updateSessionSwitchState(false) catch |err| {
-            log.err("Failed to clear session switch state: {}", .{err});
-        };
         self.clearPreparedRestorePlan();
         self.pty_id_remap.clearRetainingCapacity();
     }
@@ -2962,8 +2949,6 @@ pub const App = struct {
                 self.cancelSessionSwitch("pre-detach setup failed");
             }
         }
-
-        try self.updateSessionSwitchState(true);
 
         if (try self.sendDetachPtysRequest(.switch_detach)) |detach_request| {
             crash_context.record(

--- a/src/client.zig
+++ b/src/client.zig
@@ -179,11 +179,13 @@ pub const ClientState = struct {
     allocator: std.mem.Allocator,
     prefix_mode: bool = false,
     pty_validity: ?i64 = null,
+    suppress_unsolicited_pty_results: bool = false,
 
     pub const RequestInfo = union(enum) {
         spawn: struct { cwd: ?[]const u8 = null, old_pty_id: ?u32 = null },
         attach: struct { pty_id: i64, cwd: ?[]const u8 = null },
         detach,
+        switch_detach,
         get_server_info,
         copy_selection,
     };
@@ -215,6 +217,8 @@ pub const ServerAction = union(enum) {
     pty_exited: struct { pty_id: u32, status: u32 },
     cwd_changed: struct { pty_id: u32, cwd: []const u8 },
     detached,
+    switch_detached,
+    switch_detach_failed,
     color_query: ColorQueryTarget,
     server_info: struct { pty_validity: i64 },
     copy_to_clipboard: []const u8,
@@ -271,6 +275,9 @@ pub const ClientLogic = struct {
                     log.info("PTY {} not found, spawning new PTY with cwd", .{attach_info.pty_id});
                     return .{ .spawn_pty_with_cwd = .{ .cwd = attach_info.cwd } };
                 }
+            } else if (entry.value == .switch_detach) {
+                log.err("Session switch detach failed: {}", .{err_val});
+                return .switch_detach_failed;
             }
         }
         log.err("Error in response: {}", .{err_val});
@@ -294,6 +301,7 @@ pub const ClientLogic = struct {
                     return .{ .attached = .{ .new_pty_id = attach_info.pty_id } };
                 },
                 .detach => .detached,
+                .switch_detach => .switch_detached,
                 .get_server_info => handleServerInfoResult(state, result),
                 .copy_selection => handleCopySelectionResult(result),
             };
@@ -356,6 +364,9 @@ pub const ClientLogic = struct {
     fn handleUnsolicitedResult(state: *ClientState, result: msgpack.Value) ServerAction {
         return switch (result) {
             .integer => |i| {
+                if (state.suppress_unsolicited_pty_results) {
+                    return .none;
+                }
                 if (state.pty_id == null) {
                     state.pty_id = i;
                     return .{ .send_attach = i };
@@ -366,6 +377,9 @@ pub const ClientLogic = struct {
                 return .none;
             },
             .unsigned => |u| {
+                if (state.suppress_unsolicited_pty_results) {
+                    return .none;
+                }
                 if (state.pty_id == null) {
                     state.pty_id = @intCast(u);
                     state.attached = true;
@@ -663,6 +677,8 @@ pub const App = struct {
 
     // Current session name (owned by App)
     current_session_name: ?[]const u8 = null,
+    switch_target_session: ?[]const u8 = null,
+    session_switch_in_progress: bool = false,
     // Auto-save timer for debouncing
     autosave_timer: ?io.Task = null,
 
@@ -803,6 +819,9 @@ pub const App = struct {
         if (self.current_session_name) |name| {
             self.allocator.free(name);
         }
+        if (self.switch_target_session) |target| {
+            self.allocator.free(target);
+        }
         if (self.hit_regions.len > 0) self.allocator.free(self.hit_regions);
         if (self.split_handles.len > 0) self.allocator.free(self.split_handles);
         self.vx.deinit(self.allocator, self.tty.writer());
@@ -903,38 +922,9 @@ pub const App = struct {
             fn detachCb(ctx: *anyopaque, session_name: []const u8) anyerror!void {
                 const app_ptr: *App = @ptrCast(@alignCast(ctx));
                 try app_ptr.saveSession(session_name);
-
-                // Build array of PTY IDs to detach
-                var pty_ids = try app_ptr.allocator.alloc(msgpack.Value, app_ptr.surfaces.count());
-                defer app_ptr.allocator.free(pty_ids);
-                var i: usize = 0;
-                var key_iter = app_ptr.surfaces.keyIterator();
-                while (key_iter.next()) |pty_id| {
-                    pty_ids[i] = .{ .unsigned = pty_id.* };
-                    i += 1;
-                }
-
-                // Send single detach_session request with all PTY IDs
-                const msgid = app_ptr.state.next_msgid;
-                app_ptr.state.next_msgid +%= 1;
-
-                var arr = try app_ptr.allocator.alloc(msgpack.Value, 4);
-                arr[0] = .{ .unsigned = 0 }; // request
-                arr[1] = .{ .unsigned = msgid };
-                arr[2] = .{ .string = "detach_ptys" };
-                arr[3] = .{ .array = pty_ids };
-
-                const encoded = msgpack.encodeFromValue(app_ptr.allocator, msgpack.Value{ .array = arr }) catch {
-                    app_ptr.allocator.free(arr);
+                if (!try app_ptr.sendDetachPtysRequest(.detach)) {
                     return;
-                };
-                defer app_ptr.allocator.free(encoded);
-                app_ptr.allocator.free(arr);
-
-                // Track that we're waiting for detach response
-                try app_ptr.state.pending_requests.put(msgid, .detach);
-
-                app_ptr.sendDirect(encoded) catch {};
+                }
             }
         }.detachCb);
 
@@ -1122,6 +1112,13 @@ pub const App = struct {
                 }
             }
             return;
+        }
+
+        if (self.session_switch_in_progress) {
+            switch (event) {
+                .key_press, .key_release, .mouse => return,
+                else => {},
+            }
         }
 
         // Handle mouse events specially - do hit testing and convert to MouseEvent
@@ -1716,16 +1713,162 @@ pub const App = struct {
         self.allocator.free(msg);
     }
 
+    fn setCurrentSessionName(self: *App, session_name: []const u8) !void {
+        if (self.current_session_name) |current| {
+            self.allocator.free(current);
+        }
+        self.current_session_name = try self.allocator.dupe(u8, session_name);
+    }
+
+    fn clearCwdMap(self: *App) void {
+        var cwd_it = self.state.cwd_map.valueIterator();
+        while (cwd_it.next()) |cwd| {
+            self.allocator.free(cwd.*);
+        }
+        self.state.cwd_map.clearRetainingCapacity();
+    }
+
+    fn clearPendingAttachState(self: *App) void {
+        if (self.pending_attach_ids) |ids| {
+            self.allocator.free(ids);
+            self.pending_attach_ids = null;
+        }
+        if (self.session_json) |json| {
+            self.allocator.free(json);
+            self.session_json = null;
+        }
+        var cwd_it = self.pending_attach_cwd.valueIterator();
+        while (cwd_it.next()) |cwd| {
+            self.allocator.free(cwd.*);
+        }
+        self.pending_attach_cwd.clearRetainingCapacity();
+        self.pending_attach_count = 0;
+        self.pty_id_remap.clearRetainingCapacity();
+    }
+
+    fn sendDetachPtysRequest(self: *App, request_info: ClientState.RequestInfo) !bool {
+        if (self.surfaces.count() == 0) {
+            return false;
+        }
+
+        var pty_ids = try self.allocator.alloc(msgpack.Value, self.surfaces.count());
+        defer self.allocator.free(pty_ids);
+
+        var i: usize = 0;
+        var key_iter = self.surfaces.keyIterator();
+        while (key_iter.next()) |pty_id| {
+            pty_ids[i] = .{ .unsigned = pty_id.* };
+            i += 1;
+        }
+
+        const msgid = self.state.next_msgid;
+        self.state.next_msgid +%= 1;
+        try self.state.pending_requests.put(msgid, request_info);
+        errdefer _ = self.state.pending_requests.remove(msgid);
+
+        var arr = try self.allocator.alloc(msgpack.Value, 4);
+        defer self.allocator.free(arr);
+        arr[0] = .{ .unsigned = 0 };
+        arr[1] = .{ .unsigned = msgid };
+        arr[2] = .{ .string = "detach_ptys" };
+        arr[3] = .{ .array = pty_ids };
+
+        const encoded = try msgpack.encodeFromValue(self.allocator, msgpack.Value{ .array = arr });
+        defer self.allocator.free(encoded);
+
+        try self.sendDirect(encoded);
+        return true;
+    }
+
+    fn resetActiveSessionState(self: *App) !void {
+        if (self.render_timer) |*task| {
+            if (self.io_loop) |loop| {
+                task.cancel(loop) catch {};
+            }
+            self.render_timer = null;
+        }
+        if (self.autosave_timer) |*task| {
+            if (self.io_loop) |loop| {
+                task.cancel(loop) catch {};
+            }
+            self.autosave_timer = null;
+        }
+        if (self.paste_buffer) |*buf| {
+            buf.deinit(self.allocator);
+            self.paste_buffer = null;
+        }
+
+        var surface_it = self.surfaces.valueIterator();
+        while (surface_it.next()) |surface| {
+            surface.*.deinit();
+            self.allocator.destroy(surface.*);
+        }
+        self.surfaces.clearRetainingCapacity();
+
+        self.drag_state = null;
+        self.selection_drag_pty = null;
+        self.state.pty_id = null;
+        self.state.response_received = false;
+        self.state.attached = false;
+        self.state.connection_refused = false;
+        self.state.prefix_mode = false;
+        self.state.suppress_unsolicited_pty_results = true;
+        self.state.pending_requests.clearRetainingCapacity();
+        self.clearCwdMap();
+        self.clearPendingAttachState();
+        self.pending_color_queries.clearRetainingCapacity();
+
+        if (self.hit_regions.len > 0) {
+            self.allocator.free(self.hit_regions);
+            self.hit_regions = &.{};
+        }
+        if (self.split_handles.len > 0) {
+            self.allocator.free(self.split_handles);
+            self.split_handles = &.{};
+        }
+
+        try self.ui.clearState();
+    }
+
+    fn cancelSessionSwitch(self: *App) void {
+        self.session_switch_in_progress = false;
+        self.state.suppress_unsolicited_pty_results = false;
+        if (self.switch_target_session) |target| {
+            self.allocator.free(target);
+            self.switch_target_session = null;
+        }
+    }
+
+    fn completeSessionSwitch(self: *App) void {
+        self.session_switch_in_progress = false;
+        self.state.suppress_unsolicited_pty_results = false;
+        if (self.switch_target_session) |target| {
+            self.allocator.free(target);
+            self.switch_target_session = null;
+        }
+    }
+
+    fn beginSessionSwitchAttach(self: *App) !void {
+        const target_session = self.switch_target_session orelse return error.NoSessionSwitchTarget;
+        errdefer self.cancelSessionSwitch();
+
+        try self.resetActiveSessionState();
+        try self.startSessionAttach(target_session);
+        try self.setCurrentSessionName(target_session);
+    }
+
     fn onServerInfoReceived(self: *App) !void {
         // After receiving server info, proceed with spawn or session attach
         if (self.attach_session) |session_name| {
             // Use the attached session name
             log.info("Setting current_session_name to: {s}", .{session_name});
-            self.current_session_name = try self.allocator.dupe(u8, session_name);
+            try self.setCurrentSessionName(session_name);
+            crash_context.setSessionName(self.current_session_name);
+            crash_context.record("attach session {s}", .{session_name});
             try self.startSessionAttach(session_name);
         } else if (self.new_session_name) |name| {
             // User specified a name for new session
-            self.current_session_name = try self.allocator.dupe(u8, name);
+            try self.setCurrentSessionName(name);
             log.info("Starting new session with user-specified name: {s}", .{name});
             try self.spawnInitialPty();
         } else {
@@ -1778,6 +1921,8 @@ pub const App = struct {
     }
 
     fn startSessionAttach(self: *App, session_name: []const u8) !void {
+        crash_context.record("session restore start {s}", .{session_name});
+        self.clearPendingAttachState();
         const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
 
         const filename = try std.fmt.allocPrint(self.allocator, "{s}.json", .{session_name});
@@ -2215,6 +2360,11 @@ pub const App = struct {
                                                 app.allocator.free(ids);
                                                 app.pending_attach_ids = null;
                                             }
+                                            crash_context.record("session restore complete", .{});
+                                            app.state.suppress_unsolicited_pty_results = false;
+                                            if (app.session_switch_in_progress) {
+                                                app.completeSessionSwitch();
+                                            }
                                             try app.scheduleRender();
                                         }
                                     }
@@ -2265,16 +2415,17 @@ pub const App = struct {
                                 log.info("PTY {} exited with status {}", .{ info.pty_id, info.status });
                                 // Clean up the surface for this PTY BEFORE updating UI
                                 // so that surfaces.count() is correct when quit callback runs
-                                if (app.surfaces.fetchRemove(info.pty_id)) |entry| {
+                                const removed_surface = if (app.surfaces.fetchRemove(info.pty_id)) |entry| blk: {
                                     log.info("Cleaning up surface for exited PTY {}", .{info.pty_id});
                                     entry.value.deinit();
                                     app.allocator.destroy(entry.value);
-                                }
+                                    break :blk true;
+                                } else false;
                                 app.ui.update(.{ .pty_exited = .{ .id = info.pty_id, .status = info.status } }) catch |err| {
                                     log.err("Failed to update UI with pty_exited: {}", .{err});
                                 };
                                 // Delete session file when last PTY exits (if quit wasn't already called)
-                                if (app.surfaces.count() == 0 and !app.state.should_quit) {
+                                if (removed_surface and app.surfaces.count() == 0 and !app.state.should_quit) {
                                     // Cancel autosave timer to prevent it from recreating the file
                                     if (app.autosave_timer) |*task| {
                                         if (app.io_loop) |loop| task.cancel(loop) catch {};
@@ -2335,6 +2486,12 @@ pub const App = struct {
                                 app.vx.deviceStatusReport(app.tty.writer()) catch {};
                                 log.info("Returning from detach handler", .{});
                                 return;
+                            },
+                            .switch_detached => {
+                                try app.beginSessionSwitchAttach();
+                            },
+                            .switch_detach_failed => {
+                                app.cancelSessionSwitch();
                             },
                             .color_query => |query| {
                                 try app.handleColorQuery(query);
@@ -2616,6 +2773,9 @@ pub const App = struct {
                 return;
             }
         }
+        if (self.session_switch_in_progress) {
+            return error.SessionSwitchInProgress;
+        }
 
         // Save current session first
         if (self.current_session_name) |name| {
@@ -2623,32 +2783,20 @@ pub const App = struct {
             try self.saveSession(name);
         }
 
-        // Build arguments for exec
-        // Build arguments for exec
-        const target_z = try self.allocator.dupeZ(u8, target_session);
-        errdefer self.allocator.free(target_z);
-        const args = [_]?[*:0]const u8{
-            "prise",
-            "session",
-            "attach",
-            target_z,
-            null,
-        };
+        self.switch_target_session = try self.allocator.dupe(u8, target_session);
+        errdefer {
+            if (self.switch_target_session) |target| {
+                self.allocator.free(target);
+                self.switch_target_session = null;
+            }
+        }
 
-        log.info("Exec'ing prise session attach '{s}'", .{target_session});
+        self.session_switch_in_progress = true;
+        errdefer self.session_switch_in_progress = false;
 
-        // Restore terminal state right before exec to minimize window of failure
-        const writer = self.tty.writer();
-        self.vx.deinit(self.allocator, writer);
-
-        // Use execvpeZ with current environment
-        const err = posix.execvpeZ("prise", @ptrCast(&args), @ptrCast(std.c.environ));
-
-        // If we get here, exec failed - reinitialize terminal
-        log.err("Failed to exec prise: {}", .{err});
-        self.vx = vaxis.Vaxis.init(self.allocator, .{}) catch return err;
-        self.vx.enterAltScreen(writer) catch {};
-        return err;
+        if (!try self.sendDetachPtysRequest(.switch_detach)) {
+            try self.beginSessionSwitchAttach();
+        }
     }
 
     pub fn deleteCurrentSession(self: *App) void {
@@ -3143,6 +3291,24 @@ test "ClientLogic - processServerMessage" {
         try testing.expectEqual(123, action.attached.new_pty_id);
     }
 
+    // Test switch detach response
+    {
+        var state = ClientState.init(testing.allocator);
+        defer state.deinit();
+        try state.pending_requests.put(3, .switch_detach);
+
+        const msg = rpc.Message{
+            .response = .{
+                .msgid = 3,
+                .err = null,
+                .result = .nil,
+            },
+        };
+
+        const action = try ClientLogic.processServerMessage(&state, msg);
+        try testing.expectEqual(std.meta.Tag(ServerAction).switch_detached, std.meta.activeTag(action));
+    }
+
     // Test Redraw Notification
     {
         var state = ClientState.init(testing.allocator);
@@ -3158,6 +3324,25 @@ test "ClientLogic - processServerMessage" {
 
         const action = try ClientLogic.processServerMessage(&state, msg);
         try testing.expectEqual(std.meta.Tag(ServerAction).redraw, std.meta.activeTag(action));
+    }
+
+    // Test unsolicited PTY results can be suppressed during session switch
+    {
+        var state = ClientState.init(testing.allocator);
+        defer state.deinit();
+        state.suppress_unsolicited_pty_results = true;
+
+        const msg = rpc.Message{
+            .response = .{
+                .msgid = 99,
+                .err = null,
+                .result = .{ .integer = 456 },
+            },
+        };
+
+        const action = try ClientLogic.processServerMessage(&state, msg);
+        try testing.expectEqual(std.meta.Tag(ServerAction).none, std.meta.activeTag(action));
+        try testing.expectEqual(null, state.pty_id);
     }
 }
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -17,6 +17,7 @@ const posix = std.posix;
 const log = std.log.scoped(.client);
 
 const MAX_PASTE_SIZE = 10 * 1024 * 1024; // 10 MiB
+const MAX_SESSION_JSON_SIZE = 1024 * 1024; // 1 MiB
 
 fn nonEmptyCwd(cwd: ?[]const u8) ?[]const u8 {
     const value = cwd orelse return null;
@@ -216,7 +217,7 @@ pub const ClientState = struct {
 pub const ServerAction = union(enum) {
     none,
     send_attach: i64,
-    spawn_pty_with_cwd: struct { cwd: ?[]const u8 },
+    spawn_pty_with_cwd: struct { cwd: ?[]const u8, old_pty_id: ?u32 = null },
     redraw: msgpack.Value,
     attached: struct { new_pty_id: i64, old_pty_id: ?u32 = null },
     pty_exited: struct { pty_id: u32, status: u32 },
@@ -278,7 +279,11 @@ pub const ClientLogic = struct {
                 const attach_info = entry.value.attach;
                 if (err_val == .string and std.mem.eql(u8, err_val.string, "PTY not found")) {
                     log.info("PTY {} not found, spawning new PTY with cwd", .{attach_info.pty_id});
-                    return .{ .spawn_pty_with_cwd = .{ .cwd = attach_info.cwd } };
+                    crash_context.record("attach fallback spawn old_pty_id={d}", .{attach_info.pty_id});
+                    return .{ .spawn_pty_with_cwd = .{
+                        .cwd = attach_info.cwd,
+                        .old_pty_id = @intCast(attach_info.pty_id),
+                    } };
                 }
             } else if (entry.value == .switch_detach) {
                 log.err("Session switch detach failed: {}", .{err_val});
@@ -628,6 +633,31 @@ pub const DragState = struct {
     start_y: f64,
 };
 
+const SessionRestorePlan = struct {
+    const Self = @This();
+
+    session_name: []const u8,
+    session_json: []const u8,
+    pty_ids: []u32,
+    pty_id_cwd: std.AutoHashMap(u32, []const u8),
+    validity_matches: bool,
+    attach_count: usize,
+    spawn_fallback_count: usize,
+    remaining_attach_count: usize,
+
+    fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+        allocator.free(self.session_name);
+        allocator.free(self.session_json);
+        allocator.free(self.pty_ids);
+
+        var cwd_it = self.pty_id_cwd.valueIterator();
+        while (cwd_it.next()) |cwd| {
+            allocator.free(cwd.*);
+        }
+        self.pty_id_cwd.deinit();
+    }
+};
+
 pub const App = struct {
     connected: bool = false,
     fd: posix.fd_t = undefined,
@@ -679,10 +709,7 @@ pub const App = struct {
     pipe_recv_buffer: [4096]u8 = undefined,
     colors: Surface.TerminalColors = .{},
 
-    pending_attach_ids: ?[]u32 = null,
-    pending_attach_count: usize = 0,
-    session_json: ?[]const u8 = null,
-    pending_attach_cwd: std.AutoHashMap(u32, []const u8) = undefined,
+    prepared_restore_plan: ?SessionRestorePlan = null,
     // Maps old PTY IDs to new PTY IDs when spawning fresh PTYs due to validity mismatch
     pty_id_remap: std.AutoHashMap(u32, u32) = undefined,
 
@@ -693,7 +720,6 @@ pub const App = struct {
 
     // Current session name (owned by App)
     current_session_name: ?[]const u8 = null,
-    switch_target_session: ?[]const u8 = null,
     session_switch_in_progress: bool = false,
     // Auto-save timer for debouncing
     autosave_timer: ?io.Task = null,
@@ -731,7 +757,6 @@ pub const App = struct {
             .pipe_buf = .empty,
             .surfaces = std.AutoHashMap(u32, *Surface).init(allocator),
             .state = ClientState.init(allocator),
-            .pending_attach_cwd = std.AutoHashMap(u32, []const u8).init(allocator),
             .pty_id_remap = std.AutoHashMap(u32, u32).init(allocator),
             .pending_color_queries = .empty,
         };
@@ -825,18 +850,11 @@ pub const App = struct {
         self.msg_buffer.deinit(self.allocator);
         self.msg_arena.deinit();
         self.state.deinit();
-        var cwd_it = self.pending_attach_cwd.valueIterator();
-        while (cwd_it.next()) |cwd| {
-            self.allocator.free(cwd.*);
-        }
-        self.pending_attach_cwd.deinit();
+        self.clearPreparedRestorePlan();
         self.pty_id_remap.deinit();
         self.pending_color_queries.deinit(self.allocator);
         if (self.current_session_name) |name| {
             self.allocator.free(name);
-        }
-        if (self.switch_target_session) |target| {
-            self.allocator.free(target);
         }
         if (self.hit_regions.len > 0) self.allocator.free(self.hit_regions);
         if (self.split_handles.len > 0) self.allocator.free(self.split_handles);
@@ -938,7 +956,7 @@ pub const App = struct {
             fn detachCb(ctx: *anyopaque, session_name: []const u8) anyerror!void {
                 const app_ptr: *App = @ptrCast(@alignCast(ctx));
                 try app_ptr.saveSession(session_name);
-                if (!try app_ptr.sendDetachPtysRequest(.detach)) {
+                if ((try app_ptr.sendDetachPtysRequest(.detach)) == null) {
                     return;
                 }
             }
@@ -1678,7 +1696,7 @@ pub const App = struct {
         }
         try self.vx.render(self.tty.writer());
         log.debug("render: flushing tty", .{});
-        try self.tty.tty_writer.interface.flush();
+        try self.tty.writer().flush();
         log.debug("render: complete", .{});
 
         self.last_render_time = std.time.milliTimestamp();
@@ -1744,27 +1762,68 @@ pub const App = struct {
         self.state.cwd_map.clearRetainingCapacity();
     }
 
-    fn clearPendingAttachState(self: *App) void {
-        if (self.pending_attach_ids) |ids| {
-            self.allocator.free(ids);
-            self.pending_attach_ids = null;
+    fn clearPreparedRestorePlan(self: *App) void {
+        if (self.prepared_restore_plan) |*plan| {
+            plan.deinit(self.allocator);
+            self.prepared_restore_plan = null;
         }
-        if (self.session_json) |json| {
-            self.allocator.free(json);
-            self.session_json = null;
-        }
-        var cwd_it = self.pending_attach_cwd.valueIterator();
-        while (cwd_it.next()) |cwd| {
-            self.allocator.free(cwd.*);
-        }
-        self.pending_attach_cwd.clearRetainingCapacity();
-        self.pending_attach_count = 0;
+    }
+
+    const DetachRequest = struct {
+        msgid: u32,
+        pty_count: usize,
+    };
+
+    fn preparedRestoreSessionName(self: *const App) ?[]const u8 {
+        const plan = self.prepared_restore_plan orelse return null;
+        return plan.session_name;
+    }
+
+    fn sessionNameForLogs(session_name: ?[]const u8) []const u8 {
+        return session_name orelse "(none)";
+    }
+
+    fn updateSessionSwitchState(self: *App, active: bool) !void {
+        const target_session = if (self.preparedRestoreSessionName()) |name| name else "";
+        try self.ui.update(.{
+            .session_switch = .{
+                .active = active,
+                .target_session = target_session,
+            },
+        });
+    }
+
+    fn finishSessionSwitch(self: *App) void {
+        self.session_switch_in_progress = false;
+        self.state.suppress_unsolicited_pty_results = false;
+        self.updateSessionSwitchState(false) catch |err| {
+            log.err("Failed to clear session switch state: {}", .{err});
+        };
+        self.clearPreparedRestorePlan();
         self.pty_id_remap.clearRetainingCapacity();
     }
 
-    fn sendDetachPtysRequest(self: *App, request_info: ClientState.RequestInfo) !bool {
+    fn cancelSessionSwitch(self: *App, reason: []const u8) void {
+        const source_session = sessionNameForLogs(self.current_session_name);
+        const target_session = sessionNameForLogs(self.preparedRestoreSessionName());
+        crash_context.record(
+            "session switch cancelled from={s} to={s} reason={s}",
+            .{ source_session, target_session, reason },
+        );
+        self.finishSessionSwitch();
+    }
+
+    fn completeSessionSwitch(self: *App, source_session: ?[]const u8, target_session: []const u8) void {
+        crash_context.record(
+            "session switch restore complete from={s} to={s}",
+            .{ sessionNameForLogs(source_session), target_session },
+        );
+        self.finishSessionSwitch();
+    }
+
+    fn sendDetachPtysRequest(self: *App, request_info: ClientState.RequestInfo) !?DetachRequest {
         if (self.surfaces.count() == 0) {
-            return false;
+            return null;
         }
 
         var pty_ids = try self.allocator.alloc(msgpack.Value, self.surfaces.count());
@@ -1793,7 +1852,10 @@ pub const App = struct {
         defer self.allocator.free(encoded);
 
         try self.sendDirect(encoded);
-        return true;
+        return .{
+            .msgid = msgid,
+            .pty_count = pty_ids.len,
+        };
     }
 
     fn resetActiveSessionState(self: *App) !void {
@@ -1831,8 +1893,8 @@ pub const App = struct {
         self.state.suppress_unsolicited_pty_results = true;
         self.state.pending_requests.clearRetainingCapacity();
         self.clearCwdMap();
-        self.clearPendingAttachState();
         self.pending_color_queries.clearRetainingCapacity();
+        self.pty_id_remap.clearRetainingCapacity();
 
         if (self.hit_regions.len > 0) {
             self.allocator.free(self.hit_regions);
@@ -1846,30 +1908,24 @@ pub const App = struct {
         try self.ui.clearState();
     }
 
-    fn finishSessionSwitch(self: *App) void {
-        self.session_switch_in_progress = false;
-        self.state.suppress_unsolicited_pty_results = false;
-        if (self.switch_target_session) |target| {
-            self.allocator.free(target);
-            self.switch_target_session = null;
-        }
-    }
-
-    fn cancelSessionSwitch(self: *App) void {
-        self.finishSessionSwitch();
-    }
-
-    fn completeSessionSwitch(self: *App) void {
-        self.finishSessionSwitch();
-    }
-
     fn beginSessionSwitchAttach(self: *App) !void {
-        const target_session = self.switch_target_session orelse return error.NoSessionSwitchTarget;
-        errdefer self.cancelSessionSwitch();
-
+        const source_session = sessionNameForLogs(self.current_session_name);
+        const target_session = self.preparedRestoreSessionName() orelse return error.NoPreparedRestorePlan;
+        crash_context.record(
+            "session switch detach acknowledged from={s} to={s}",
+            .{ source_session, target_session },
+        );
+        crash_context.record(
+            "session switch reset start from={s} to={s}",
+            .{ source_session, target_session },
+        );
         try self.resetActiveSessionState();
-        try self.startSessionAttach(target_session);
-        try self.setCurrentSessionName(target_session);
+        crash_context.record(
+            "session switch reset finish from={s} to={s}",
+            .{ source_session, target_session },
+        );
+        try self.scheduleRender();
+        try self.applyPreparedSessionRestore();
     }
 
     fn onServerInfoReceived(self: *App) !void {
@@ -1880,7 +1936,13 @@ pub const App = struct {
             try self.setCurrentSessionName(session_name);
             crash_context.setSessionName(self.current_session_name);
             crash_context.record("attach session {s}", .{session_name});
-            try self.startSessionAttach(session_name);
+            var plan = try self.preflightSessionRestore(session_name);
+            var plan_stored = false;
+            errdefer if (!plan_stored) plan.deinit(self.allocator);
+            self.clearPreparedRestorePlan();
+            self.prepared_restore_plan = plan;
+            plan_stored = true;
+            try self.applyPreparedSessionRestore();
         } else if (self.new_session_name) |name| {
             // User specified a name for new session
             try self.setCurrentSessionName(name);
@@ -1936,63 +1998,124 @@ pub const App = struct {
         try self.sendDirect(msg);
     }
 
-    fn startSessionAttach(self: *App, session_name: []const u8) !void {
-        crash_context.record("session restore start {s}", .{session_name});
-        self.clearPendingAttachState();
+    fn sessionFilePath(self: *App, session_name: []const u8) ![]u8 {
         const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
-
         const filename = try std.fmt.allocPrint(self.allocator, "{s}.json", .{session_name});
         defer self.allocator.free(filename);
 
-        const path = try std.fs.path.join(self.allocator, &.{ home, ".local", "state", "prise", "sessions", filename });
-        defer self.allocator.free(path);
+        return std.fs.path.join(self.allocator, &.{ home, ".local", "state", "prise", "sessions", filename });
+    }
 
+    fn loadSessionRestorePlanFromPath(
+        allocator: std.mem.Allocator,
+        path: []const u8,
+        session_name: []const u8,
+        current_validity: ?i64,
+    ) !SessionRestorePlan {
         const file = std.fs.openFileAbsolute(path, .{}) catch |err| {
-            log.err("Failed to open session file {s}: {}", .{ path, err });
+            log.info("Failed to open session file {s}: {}", .{ path, err });
             return err;
         };
         defer file.close();
 
-        const json = try file.readToEndAlloc(self.allocator, 1024 * 1024);
-        self.session_json = json;
+        const json = try file.readToEndAlloc(allocator, MAX_SESSION_JSON_SIZE);
+        errdefer allocator.free(json);
+        return buildSessionRestorePlanFromOwnedJson(allocator, session_name, json, current_validity);
+    }
 
-        // Check if pty_validity matches - if not, skip attach and spawn fresh
-        const saved_validity = extractPtyValidityFromJson(self.allocator, json);
+    fn buildSessionRestorePlanFromOwnedJson(
+        allocator: std.mem.Allocator,
+        session_name: []const u8,
+        session_json: []const u8,
+        current_validity: ?i64,
+    ) !SessionRestorePlan {
+        const pty_ids = try extractPtyIdsFromJson(allocator, session_json);
+        errdefer allocator.free(pty_ids);
+        if (pty_ids.len == 0) {
+            return error.NoSessionsFound;
+        }
+
+        var pty_id_cwd = try extractPtyIdCwdPairs(allocator, session_json);
+        errdefer {
+            var cwd_it = pty_id_cwd.valueIterator();
+            while (cwd_it.next()) |cwd| {
+                allocator.free(cwd.*);
+            }
+            pty_id_cwd.deinit();
+        }
+
+        const saved_validity = extractPtyValidityFromJson(allocator, session_json);
         const validity_matches = if (saved_validity) |saved| blk: {
-            if (self.state.pty_validity) |current| {
+            if (current_validity) |current| {
                 break :blk saved == current;
             }
             break :blk false;
         } else false;
 
         if (!validity_matches) {
-            log.info("pty_validity mismatch (saved={?}, current={?}), spawning fresh PTYs", .{ saved_validity, self.state.pty_validity });
+            log.info("pty_validity mismatch (saved={?}, current={?}), spawning fresh PTYs", .{ saved_validity, current_validity });
+            crash_context.record(
+                "session restore spawn fallback saved_validity={?} current_validity={?}",
+                .{ saved_validity, current_validity },
+            );
         }
 
-        const pty_ids = try extractPtyIdsFromJson(self.allocator, json);
-        if (pty_ids.len == 0) {
-            log.err("No PTY IDs found in session", .{});
-            self.allocator.free(json);
-            self.session_json = null;
-            return error.NoSessionsFound;
-        }
+        return .{
+            .session_name = try allocator.dupe(u8, session_name),
+            .session_json = session_json,
+            .pty_ids = pty_ids,
+            .pty_id_cwd = pty_id_cwd,
+            .validity_matches = validity_matches,
+            .attach_count = if (validity_matches) pty_ids.len else 0,
+            .spawn_fallback_count = if (validity_matches) 0 else pty_ids.len,
+            .remaining_attach_count = 0,
+        };
+    }
 
-        // Extract PTY ID + cwd pairs for fallback spawning if attach fails
-        self.pending_attach_cwd = try extractPtyIdCwdPairs(self.allocator, json);
+    fn preflightSessionRestore(self: *App, session_name: []const u8) !SessionRestorePlan {
+        crash_context.record("session restore preflight start {s}", .{session_name});
+        const path = try self.sessionFilePath(session_name);
+        defer self.allocator.free(path);
 
-        log.info("Attaching to {} PTYs from session {s}", .{ pty_ids.len, session_name });
-        self.pending_attach_ids = pty_ids;
-        self.pending_attach_count = pty_ids.len;
+        const plan = loadSessionRestorePlanFromPath(
+            self.allocator,
+            path,
+            session_name,
+            self.state.pty_validity,
+        ) catch |err| {
+            crash_context.record(
+                "session restore preflight failed {s}: {s}",
+                .{ session_name, @errorName(err) },
+            );
+            return err;
+        };
 
-        for (pty_ids) |pty_id| {
-            const cwd = nonEmptyCwd(self.pending_attach_cwd.get(pty_id));
+        crash_context.record(
+            "session restore preflight success {s} attach_count={d} spawn_fallback_count={d}",
+            .{ session_name, plan.attach_count, plan.spawn_fallback_count },
+        );
+        return plan;
+    }
 
-            // If validity doesn't match, spawn fresh instead of attaching
-            if (!validity_matches) {
+    fn applyPreparedSessionRestore(self: *App) !void {
+        const plan = if (self.prepared_restore_plan) |*value| value else return error.NoPreparedRestorePlan;
+        std.debug.assert(plan.pty_ids.len > 0);
+
+        crash_context.record(
+            "session restore apply start {s} attach_count={d} spawn_fallback_count={d}",
+            .{ plan.session_name, plan.attach_count, plan.spawn_fallback_count },
+        );
+        plan.remaining_attach_count = plan.pty_ids.len;
+
+        log.info("Attaching to {} PTYs from session {s}", .{ plan.pty_ids.len, plan.session_name });
+        for (plan.pty_ids) |pty_id| {
+            const cwd = nonEmptyCwd(plan.pty_id_cwd.get(pty_id));
+
+            if (!plan.validity_matches) {
                 const msgid = self.state.next_msgid;
                 self.state.next_msgid += 1;
                 try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = cwd, .old_pty_id = pty_id } });
-                try self.spawnPtyWithCwd(msgid, cwd);
+                try self.spawnPtyWithCwd(msgid, cwd, plan.session_name);
                 continue;
             }
 
@@ -2000,7 +2123,6 @@ pub const App = struct {
             self.state.next_msgid += 1;
             try self.state.pending_requests.put(msgid, .{ .attach = .{ .pty_id = @intCast(pty_id), .cwd = cwd } });
 
-            // Server expects params as array: [pty_id, macos_option_as_alt]
             const macos_option_as_alt = self.ui.getMacosOptionAsAlt();
             var params = try self.allocator.alloc(msgpack.Value, 2);
             params[0] = .{ .unsigned = pty_id };
@@ -2022,6 +2144,28 @@ pub const App = struct {
         }
     }
 
+    fn completePreparedSessionRestore(self: *App) !void {
+        const target_session = self.preparedRestoreSessionName() orelse return error.NoPreparedRestorePlan;
+
+        log.info("All PTYs attached, restoring session state", .{});
+        if (self.prepared_restore_plan) |plan| {
+            try self.ui.setStateFromJson(plan.session_json, ptyLookup, self);
+        }
+
+        crash_context.record("session restore complete {s}", .{target_session});
+        self.state.suppress_unsolicited_pty_results = false;
+
+        if (self.session_switch_in_progress) {
+            const source_session = self.current_session_name;
+            try self.setCurrentSessionName(target_session);
+            crash_context.setSessionName(self.current_session_name);
+            self.completeSessionSwitch(source_session, target_session);
+        }
+
+        self.clearPreparedRestorePlan();
+        try self.scheduleRender();
+    }
+
     fn extractPtyValidityFromJson(allocator: std.mem.Allocator, json: []const u8) ?i64 {
         const parsed = std.json.parseFromSlice(std.json.Value, allocator, json, .{}) catch return null;
         defer parsed.deinit();
@@ -2032,7 +2176,7 @@ pub const App = struct {
         return validity_val.integer;
     }
 
-    fn spawnPtyWithCwd(self: *App, msgid: u32, cwd: ?[]const u8) !void {
+    fn spawnPtyWithCwd(self: *App, msgid: u32, cwd: ?[]const u8, session_name: []const u8) !void {
         const ws = try vaxis.Tty.getWinsize(self.tty.fd);
         const resolved_cwd = nonEmptyCwd(cwd);
 
@@ -2046,6 +2190,7 @@ pub const App = struct {
             const env_str = try std.fmt.allocPrint(self.allocator, "{s}={s}", .{ entry.key_ptr.*, entry.value_ptr.* });
             try env_array.append(self.allocator, .{ .string = env_str });
         }
+        try self.appendSessionEnvNamed(&env_array, self.allocator, session_name);
 
         const macos_option_as_alt = self.ui.getMacosOptionAsAlt();
         const param_count: usize = if (resolved_cwd != null) 6 else 5;
@@ -2064,6 +2209,22 @@ pub const App = struct {
         try self.sendDirect(msg);
         self.allocator.free(msg);
     }
+
+    fn appendSessionEnvNamed(
+        self: *App,
+        env_array: *std.ArrayList(msgpack.Value),
+        string_allocator: std.mem.Allocator,
+        session_name: []const u8,
+    ) !void {
+        const session_env = try std.fmt.allocPrint(string_allocator, "PRISE_SESSION={s}", .{session_name});
+        try env_array.append(self.allocator, .{ .string = session_env });
+    }
+
+    fn appendSessionEnv(self: *App, env_array: *std.ArrayList(msgpack.Value), string_allocator: std.mem.Allocator) !void {
+        const session_name = self.current_session_name orelse return;
+        try self.appendSessionEnvNamed(env_array, string_allocator, session_name);
+    }
+
 
     fn onSendComplete(_: *io.Loop, completion: io.Completion) anyerror!void {
         const app = completion.userdataCast(@This());
@@ -2172,7 +2333,7 @@ pub const App = struct {
 
                                 if (app.surfaces.get(pty_id)) |surface| {
                                     // Skip pty_attach events during session restore - set_state will restore the UI tree
-                                    const is_session_restore = app.pending_attach_count > 0 or app.session_json != null;
+                                    const is_session_restore = app.prepared_restore_plan != null;
                                     if (!is_session_restore) {
                                         log.info("Updating UI with pty_attach for {}", .{pty_id});
                                         // Send pty_attach event to Lua UI
@@ -2361,28 +2522,11 @@ pub const App = struct {
                                     defer app.allocator.free(resize_msg);
                                     try app.sendDirect(resize_msg);
 
-                                    // Check if we're in session attach mode and all PTYs attached
-                                    if (app.pending_attach_count > 0) {
-                                        app.pending_attach_count -= 1;
-                                        if (app.pending_attach_count == 0) {
-                                            log.info("All PTYs attached, restoring session state", .{});
-                                            if (app.session_json) |json| {
-                                                app.ui.setStateFromJson(json, ptyLookup, app) catch |err| {
-                                                    log.err("Failed to restore session state: {}", .{err});
-                                                };
-                                                app.allocator.free(json);
-                                                app.session_json = null;
-                                            }
-                                            if (app.pending_attach_ids) |ids| {
-                                                app.allocator.free(ids);
-                                                app.pending_attach_ids = null;
-                                            }
-                                            crash_context.record("session restore complete", .{});
-                                            app.state.suppress_unsolicited_pty_results = false;
-                                            if (app.session_switch_in_progress) {
-                                                app.completeSessionSwitch();
-                                            }
-                                            try app.scheduleRender();
+                                    if (app.prepared_restore_plan) |*plan| {
+                                        std.debug.assert(plan.remaining_attach_count > 0);
+                                        plan.remaining_attach_count -= 1;
+                                        if (plan.remaining_attach_count == 0) {
+                                            try app.completePreparedSessionRestore();
                                         }
                                     }
                                 }
@@ -2392,40 +2536,14 @@ pub const App = struct {
                                 log.info("Spawning new PTY with cwd: {s}", .{if (cwd) |c| c else "default"});
                                 const msgid = app.state.next_msgid;
                                 app.state.next_msgid += 1;
-                                try app.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = cwd } });
-
-                                // Build env array from current process environment
-                                var env_map = try std.process.getEnvMap(app.allocator);
-                                defer env_map.deinit();
-
-                                var env_array = std.ArrayList(msgpack.Value).empty;
-                                defer env_array.deinit(app.allocator);
-                                var env_it = env_map.iterator();
-                                while (env_it.next()) |entry| {
-                                    const env_str = try std.fmt.allocPrint(app.allocator, "{s}={s}", .{ entry.key_ptr.*, entry.value_ptr.* });
-                                    try env_array.append(app.allocator, .{ .string = env_str });
-                                }
-
-                                // Build spawn_pty params with env and optional cwd
-                                const param_count: usize = if (cwd != null) 2 else 1;
-                                var kv = try app.allocator.alloc(msgpack.Value.KeyValue, param_count);
-                                defer app.allocator.free(kv);
-                                kv[0] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
-                                if (cwd) |resolved_cwd| {
-                                    kv[1] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = resolved_cwd } };
-                                }
-
-                                var arr = try app.allocator.alloc(msgpack.Value, 4);
-                                defer app.allocator.free(arr);
-                                arr[0] = .{ .unsigned = 0 };
-                                arr[1] = .{ .unsigned = msgid };
-                                arr[2] = .{ .string = "spawn_pty" };
-                                arr[3] = .{ .map = kv };
-
-                                const encoded = try msgpack.encodeFromValue(app.allocator, msgpack.Value{ .array = arr });
-                                defer app.allocator.free(encoded);
-
-                                try app.sendDirect(encoded);
+                                const restore_session = if (app.prepared_restore_plan) |plan|
+                                    plan.session_name
+                                else
+                                    app.current_session_name orelse return error.NoCurrentSession;
+                                try app.state.pending_requests.put(msgid, .{
+                                    .spawn = .{ .cwd = cwd, .old_pty_id = info.old_pty_id },
+                                });
+                                try app.spawnPtyWithCwd(msgid, cwd, restore_session);
                             },
                             .pty_exited => |info| {
                                 log.info("PTY {} exited with status {}", .{ info.pty_id, info.status });
@@ -2504,10 +2622,20 @@ pub const App = struct {
                                 return;
                             },
                             .switch_detached => {
-                                try app.beginSessionSwitchAttach();
+                                app.beginSessionSwitchAttach() catch |err| {
+                                    crash_context.record(
+                                        "session switch apply fatal from={s} to={s} err={s}",
+                                        .{
+                                            sessionNameForLogs(app.current_session_name),
+                                            sessionNameForLogs(app.preparedRestoreSessionName()),
+                                            @errorName(err),
+                                        },
+                                    );
+                                    return err;
+                                };
                             },
                             .switch_detach_failed => {
-                                app.cancelSessionSwitch();
+                                app.cancelSessionSwitch("detach rejected");
                             },
                             .color_query => |query| {
                                 try app.handleColorQuery(query);
@@ -2794,26 +2922,69 @@ pub const App = struct {
             return error.SessionSwitchInProgress;
         }
 
-        // Save current session first
+        const source_session = sessionNameForLogs(self.current_session_name);
+        crash_context.record(
+            "session switch requested from={s} to={s}",
+            .{ source_session, target_session },
+        );
+        crash_context.record(
+            "session switch preflight start from={s} to={s}",
+            .{ source_session, target_session },
+        );
+
+        var plan = self.preflightSessionRestore(target_session) catch |err| {
+            crash_context.record(
+                "session switch preflight failed from={s} to={s} err={s}",
+                .{ source_session, target_session, @errorName(err) },
+            );
+            return err;
+        };
+        var plan_stored = false;
+        errdefer if (!plan_stored) plan.deinit(self.allocator);
+
+        crash_context.record(
+            "session switch preflight success from={s} to={s} attach_count={d} spawn_fallback_count={d}",
+            .{ source_session, target_session, plan.attach_count, plan.spawn_fallback_count },
+        );
+
         if (self.current_session_name) |name| {
             log.info("Saving current session '{s}' before switch", .{name});
             try self.saveSession(name);
         }
 
-        self.switch_target_session = try self.allocator.dupe(u8, target_session);
+        self.clearPreparedRestorePlan();
+        self.prepared_restore_plan = plan;
+        plan_stored = true;
+        self.session_switch_in_progress = true;
+        var pre_detach_phase = true;
         errdefer {
-            if (self.switch_target_session) |target| {
-                self.allocator.free(target);
-                self.switch_target_session = null;
+            if (pre_detach_phase and self.session_switch_in_progress) {
+                self.cancelSessionSwitch("pre-detach setup failed");
             }
         }
 
-        self.session_switch_in_progress = true;
-        errdefer self.session_switch_in_progress = false;
+        try self.updateSessionSwitchState(true);
 
-        if (!try self.sendDetachPtysRequest(.switch_detach)) {
-            try self.beginSessionSwitchAttach();
+        if (try self.sendDetachPtysRequest(.switch_detach)) |detach_request| {
+            crash_context.record(
+                "session switch detach request sent from={s} to={s} msgid={d} ptys={d}",
+                .{ source_session, target_session, detach_request.msgid, detach_request.pty_count },
+            );
+            return;
         }
+
+        pre_detach_phase = false;
+        crash_context.record(
+            "session switch skipping detach from={s} to={s} reason=no-live-ptys",
+            .{ source_session, target_session },
+        );
+        self.beginSessionSwitchAttach() catch |err| {
+            crash_context.record(
+                "session switch apply fatal from={s} to={s} err={s}",
+                .{ source_session, target_session, @errorName(err) },
+            );
+            return err;
+        };
     }
 
     pub fn deleteCurrentSession(self: *App) void {
@@ -3324,6 +3495,26 @@ test "ClientLogic - processServerMessage" {
         try testing.expectEqual(std.meta.Tag(ServerAction).switch_detached, std.meta.activeTag(action));
     }
 
+    // Test attach fallback preserves old PTY ID for restore remapping
+    {
+        var state = ClientState.init(testing.allocator);
+        defer state.deinit();
+        try state.pending_requests.put(4, .{ .attach = .{ .pty_id = 321, .cwd = "/tmp/demo" } });
+
+        const msg = rpc.Message{
+            .response = .{
+                .msgid = 4,
+                .err = .{ .string = "PTY not found" },
+                .result = .nil,
+            },
+        };
+
+        const action = try ClientLogic.processServerMessage(&state, msg);
+        try testing.expectEqual(std.meta.Tag(ServerAction).spawn_pty_with_cwd, std.meta.activeTag(action));
+        try testing.expectEqualStrings("/tmp/demo", action.spawn_pty_with_cwd.cwd.?);
+        try testing.expectEqual(@as(?u32, 321), action.spawn_pty_with_cwd.old_pty_id);
+    }
+
     // Test Redraw Notification
     {
         var state = ClientState.init(testing.allocator);
@@ -3506,6 +3697,145 @@ test "extractPtyIdCwdPairs skips missing and empty cwd" {
     try testing.expectEqualStrings("/tmp/project", pairs.get(1).?);
     try testing.expect(!pairs.contains(2));
     try testing.expect(!pairs.contains(3));
+}
+
+test "loadSessionRestorePlanFromPath fails for missing target session" {
+    const testing = std.testing;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const path = try std.fs.path.join(testing.allocator, &.{ root, "missing.json" });
+    defer testing.allocator.free(path);
+
+    try testing.expectError(
+        error.FileNotFound,
+        App.loadSessionRestorePlanFromPath(testing.allocator, path, "missing", 123),
+    );
+}
+
+test "loadSessionRestorePlanFromPath fails for corrupt session json" {
+    const testing = std.testing;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{
+        .sub_path = "corrupt.json",
+        .data = "{",
+    });
+
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "corrupt.json");
+    defer testing.allocator.free(path);
+
+    var plan = App.loadSessionRestorePlanFromPath(testing.allocator, path, "corrupt", 123) catch {
+        return;
+    };
+    defer plan.deinit(testing.allocator);
+    return error.TestUnexpectedResult;
+}
+
+test "buildSessionRestorePlanFromOwnedJson fails for pty-less session json" {
+    const testing = std.testing;
+
+    const json = try testing.allocator.dupe(u8,
+        \\{
+        \\  "tabs": []
+        \\}
+    );
+    errdefer testing.allocator.free(json);
+
+    try testing.expectError(
+        error.NoSessionsFound,
+        App.buildSessionRestorePlanFromOwnedJson(testing.allocator, "empty", json, 123),
+    );
+    testing.allocator.free(json);
+}
+
+test "buildSessionRestorePlanFromOwnedJson ignores empty cwd values" {
+    const testing = std.testing;
+
+    const json = try testing.allocator.dupe(u8,
+        \\{
+        \\  "pty_validity": 42,
+        \\  "root": {
+        \\    "type": "split",
+        \\    "children": [
+        \\      { "type": "pane", "id": 1, "pty_id": 11, "cwd": "/tmp/project" },
+        \\      { "type": "pane", "id": 2, "pty_id": 12, "cwd": "" },
+        \\      { "type": "pane", "id": 3, "pty_id": 13 }
+        \\    ]
+        \\  }
+        \\}
+    );
+    var plan = try App.buildSessionRestorePlanFromOwnedJson(testing.allocator, "demo", json, 42);
+    defer plan.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 3), plan.pty_ids.len);
+    try testing.expectEqualStrings("/tmp/project", plan.pty_id_cwd.get(11).?);
+    try testing.expect(!plan.pty_id_cwd.contains(12));
+    try testing.expect(!plan.pty_id_cwd.contains(13));
+}
+
+test "buildSessionRestorePlanFromOwnedJson computes attach and spawn fallback counts" {
+    const testing = std.testing;
+
+    const matching_json = try testing.allocator.dupe(u8,
+        \\{
+        \\  "pty_validity": 7,
+        \\  "root": {
+        \\    "type": "split",
+        \\    "children": [
+        \\      { "type": "pane", "id": 1, "pty_id": 21 },
+        \\      { "type": "pane", "id": 2, "pty_id": 22 }
+        \\    ]
+        \\  }
+        \\}
+    );
+    var matching_plan = try App.buildSessionRestorePlanFromOwnedJson(testing.allocator, "match", matching_json, 7);
+    defer matching_plan.deinit(testing.allocator);
+    try testing.expect(matching_plan.validity_matches);
+    try testing.expectEqual(@as(usize, 2), matching_plan.attach_count);
+    try testing.expectEqual(@as(usize, 0), matching_plan.spawn_fallback_count);
+
+    const mismatch_json = try testing.allocator.dupe(u8,
+        \\{
+        \\  "pty_validity": 9,
+        \\  "root": {
+        \\    "type": "split",
+        \\    "children": [
+        \\      { "type": "pane", "id": 1, "pty_id": 31 },
+        \\      { "type": "pane", "id": 2, "pty_id": 32 }
+        \\    ]
+        \\  }
+        \\}
+    );
+    var mismatch_plan = try App.buildSessionRestorePlanFromOwnedJson(testing.allocator, "mismatch", mismatch_json, 7);
+    defer mismatch_plan.deinit(testing.allocator);
+    try testing.expect(!mismatch_plan.validity_matches);
+    try testing.expectEqual(@as(usize, 0), mismatch_plan.attach_count);
+    try testing.expectEqual(@as(usize, 2), mismatch_plan.spawn_fallback_count);
+}
+
+test "switchToSession leaves state untouched when preflight fails" {
+    var backing_buffer: [8192]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&backing_buffer);
+    const allocator = fba.allocator();
+
+    var app: App = undefined;
+    app.allocator = allocator;
+    app.state = ClientState.init(allocator);
+    app.current_session_name = "source";
+    app.prepared_restore_plan = null;
+    app.session_switch_in_progress = false;
+
+    try std.testing.expectError(error.FileNotFound, app.switchToSession("missing"));
+    try std.testing.expectEqualStrings("source", app.current_session_name.?);
+    try std.testing.expect(!app.session_switch_in_progress);
+    try std.testing.expect(app.prepared_restore_plan == null);
 }
 
 test "UnixSocketClient - successful connection" {

--- a/src/client.zig
+++ b/src/client.zig
@@ -18,6 +18,11 @@ const log = std.log.scoped(.client);
 
 const MAX_PASTE_SIZE = 10 * 1024 * 1024; // 10 MiB
 
+fn nonEmptyCwd(cwd: ?[]const u8) ?[]const u8 {
+    const value = cwd orelse return null;
+    return if (value.len > 0) value else null;
+}
+
 pub const MsgId = enum(u16) {
     spawn_pty = 1,
     attach_pty = 2,
@@ -292,7 +297,9 @@ pub const ClientLogic = struct {
                 .attach => |attach_info| {
                     state.pty_id = attach_info.pty_id;
                     state.attached = true;
-                    if (attach_info.cwd) |c| {
+                    crash_context.setCurrentPty(@intCast(attach_info.pty_id));
+                    crash_context.record("attached existing pty_id={d}", .{attach_info.pty_id});
+                    if (nonEmptyCwd(attach_info.cwd)) |c| {
                         const owned_cwd = state.allocator.dupe(u8, c) catch return .{ .attached = .{ .new_pty_id = attach_info.pty_id } };
                         state.cwd_map.put(attach_info.pty_id, owned_cwd) catch {
                             state.allocator.free(owned_cwd);
@@ -350,7 +357,9 @@ pub const ClientLogic = struct {
         if (id >= 0) {
             state.pty_id = id;
             state.attached = true;
-            if (cwd) |c| {
+            crash_context.setCurrentPty(@intCast(id));
+            crash_context.record("attached pty_id={d} old_pty_id={?}", .{ id, old_pty_id });
+            if (nonEmptyCwd(cwd)) |c| {
                 const owned_cwd = state.allocator.dupe(u8, c) catch return .{ .attached = .{ .new_pty_id = id, .old_pty_id = old_pty_id } };
                 state.cwd_map.put(id, owned_cwd) catch {
                     state.allocator.free(owned_cwd);
@@ -506,6 +515,13 @@ pub const ClientLogic = struct {
 
         const cwd = if (cwd_val) |v| (if (v == .string) v.string else null) else return .none;
         const cwd_str = cwd orelse return .none;
+
+        if (cwd_str.len == 0) {
+            if (state.cwd_map.fetchRemove(pty_id)) |entry| {
+                state.allocator.free(entry.value);
+            }
+            return .{ .cwd_changed = .{ .pty_id = @intCast(pty_id), .cwd = cwd_str } };
+        }
 
         if (state.cwd_map.getPtr(pty_id)) |entry| {
             state.allocator.free(entry.*);
@@ -1881,10 +1897,11 @@ pub const App = struct {
 
     fn spawnInitialPty(self: *App) !void {
         const ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const initial_cwd = nonEmptyCwd(self.initial_cwd);
 
         const msgid = self.state.next_msgid;
         self.state.next_msgid += 1;
-        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = self.initial_cwd } });
+        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = initial_cwd } });
 
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();
@@ -1902,16 +1919,16 @@ pub const App = struct {
         }
 
         const macos_option_as_alt = self.ui.getMacosOptionAsAlt();
-        const param_count: usize = if (self.initial_cwd != null) 6 else 5;
+        const param_count: usize = if (initial_cwd != null) 6 else 5;
         var params_kv = try self.allocator.alloc(msgpack.Value.KeyValue, param_count);
         defer self.allocator.free(params_kv);
-        log.info("Sending spawn_pty: rows={} cols={} cwd={?s} env_count={}", .{ ws.rows, ws.cols, self.initial_cwd, env_array.items.len });
+        log.info("Sending spawn_pty: rows={} cols={} cwd={?s} env_count={}", .{ ws.rows, ws.cols, initial_cwd, env_array.items.len });
         params_kv[0] = .{ .key = .{ .string = "rows" }, .value = .{ .unsigned = ws.rows } };
         params_kv[1] = .{ .key = .{ .string = "cols" }, .value = .{ .unsigned = ws.cols } };
         params_kv[2] = .{ .key = .{ .string = "attach" }, .value = .{ .boolean = true } };
         params_kv[3] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
         params_kv[4] = .{ .key = .{ .string = "macos_option_as_alt" }, .value = .{ .string = macos_option_as_alt } };
-        if (self.initial_cwd) |cwd| {
+        if (initial_cwd) |cwd| {
             params_kv[5] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = cwd } };
         }
         const params_val = msgpack.Value{ .map = params_kv };
@@ -1969,7 +1986,7 @@ pub const App = struct {
         self.pending_attach_count = pty_ids.len;
 
         for (pty_ids) |pty_id| {
-            const cwd = self.pending_attach_cwd.get(pty_id);
+            const cwd = nonEmptyCwd(self.pending_attach_cwd.get(pty_id));
 
             // If validity doesn't match, spawn fresh instead of attaching
             if (!validity_matches) {
@@ -2018,6 +2035,7 @@ pub const App = struct {
 
     fn spawnPtyWithCwd(self: *App, msgid: u32, cwd: ?[]const u8) !void {
         const ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const resolved_cwd = nonEmptyCwd(cwd);
 
         var env_map = try std.process.getEnvMap(self.allocator);
         defer env_map.deinit();
@@ -2031,7 +2049,7 @@ pub const App = struct {
         }
 
         const macos_option_as_alt = self.ui.getMacosOptionAsAlt();
-        const param_count: usize = if (cwd != null) 6 else 5;
+        const param_count: usize = if (resolved_cwd != null) 6 else 5;
         var params_kv = try self.allocator.alloc(msgpack.Value.KeyValue, param_count);
         defer self.allocator.free(params_kv);
         params_kv[0] = .{ .key = .{ .string = "rows" }, .value = .{ .unsigned = ws.rows } };
@@ -2039,7 +2057,7 @@ pub const App = struct {
         params_kv[2] = .{ .key = .{ .string = "attach" }, .value = .{ .boolean = true } };
         params_kv[3] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
         params_kv[4] = .{ .key = .{ .string = "macos_option_as_alt" }, .value = .{ .string = macos_option_as_alt } };
-        if (cwd) |c| {
+        if (resolved_cwd) |c| {
             params_kv[5] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = c } };
         }
         const params_val = msgpack.Value{ .map = params_kv };
@@ -2371,10 +2389,11 @@ pub const App = struct {
                                 }
                             },
                             .spawn_pty_with_cwd => |info| {
-                                log.info("Spawning new PTY with cwd: {s}", .{if (info.cwd) |c| c else "default"});
+                                const cwd = nonEmptyCwd(info.cwd);
+                                log.info("Spawning new PTY with cwd: {s}", .{if (cwd) |c| c else "default"});
                                 const msgid = app.state.next_msgid;
                                 app.state.next_msgid += 1;
-                                try app.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = info.cwd } });
+                                try app.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = cwd } });
 
                                 // Build env array from current process environment
                                 var env_map = try std.process.getEnvMap(app.allocator);
@@ -2389,14 +2408,12 @@ pub const App = struct {
                                 }
 
                                 // Build spawn_pty params with env and optional cwd
-                                const param_count: usize = if (info.cwd != null) 2 else 1;
+                                const param_count: usize = if (cwd != null) 2 else 1;
                                 var kv = try app.allocator.alloc(msgpack.Value.KeyValue, param_count);
                                 defer app.allocator.free(kv);
                                 kv[0] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
-                                if (info.cwd) |cwd| {
-                                    if (cwd.len > 0) {
-                                        kv[1] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = cwd } };
-                                    }
+                                if (cwd) |resolved_cwd| {
+                                    kv[1] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = resolved_cwd } };
                                 }
 
                                 var arr = try app.allocator.alloc(msgpack.Value, 4);
@@ -2562,9 +2579,10 @@ pub const App = struct {
     pub fn spawnPty(self: *App, opts: UI.SpawnOptions) !void {
         const msgid = self.state.next_msgid;
         self.state.next_msgid += 1;
+        const cwd = nonEmptyCwd(opts.cwd);
 
         log.info("spawnPty: sending request msgid={}", .{msgid});
-        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = opts.cwd } });
+        try self.state.pending_requests.put(msgid, .{ .spawn = .{ .cwd = cwd } });
 
         // Build env array from current process environment
         var env_map = try std.process.getEnvMap(self.allocator);
@@ -2578,7 +2596,7 @@ pub const App = struct {
             try env_array.append(self.allocator, .{ .string = env_str });
         }
 
-        const num_params: usize = if (opts.cwd != null) 5 else 4;
+        const num_params: usize = if (cwd != null) 5 else 4;
         var map_items = try self.allocator.alloc(msgpack.Value.KeyValue, num_params);
         defer self.allocator.free(map_items);
 
@@ -2586,8 +2604,8 @@ pub const App = struct {
         map_items[1] = .{ .key = .{ .string = "cols" }, .value = .{ .unsigned = opts.cols } };
         map_items[2] = .{ .key = .{ .string = "attach" }, .value = .{ .boolean = opts.attach } };
         map_items[3] = .{ .key = .{ .string = "env" }, .value = .{ .array = env_array.items } };
-        if (opts.cwd) |cwd| {
-            map_items[4] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = cwd } };
+        if (cwd) |resolved_cwd| {
+            map_items[4] = .{ .key = .{ .string = "cwd" }, .value = .{ .string = resolved_cwd } };
         }
 
         const params = msgpack.Value{ .map = map_items };
@@ -2992,13 +3010,11 @@ pub const App = struct {
                         if (obj.get("pty_id")) |pty_id_val| {
                             if (pty_id_val == .integer) {
                                 const pty_id: u32 = @intCast(pty_id_val.integer);
-                                var cwd: ?[]const u8 = null;
                                 if (obj.get("cwd")) |cwd_val| {
-                                    if (cwd_val == .string) {
-                                        cwd = try allocator.dupe(u8, cwd_val.string);
+                                    if (cwd_val == .string and cwd_val.string.len > 0) {
+                                        try pairs.put(pty_id, try allocator.dupe(u8, cwd_val.string));
                                     }
                                 }
-                                try pairs.put(pty_id, cwd orelse try allocator.dupe(u8, ""));
                             }
                         }
                     }
@@ -3461,6 +3477,36 @@ test "ClientLogic - shouldFlush" {
 
         try testing.expect(!ClientLogic.shouldFlush(params));
     }
+}
+
+test "extractPtyIdCwdPairs skips missing and empty cwd" {
+    const testing = std.testing;
+
+    const json =
+        \\{
+        \\  "root": {
+        \\    "type": "split",
+        \\    "children": [
+        \\      { "type": "pane", "id": 1, "pty_id": 1, "cwd": "/tmp/project" },
+        \\      { "type": "pane", "id": 2, "pty_id": 2, "cwd": "" },
+        \\      { "type": "pane", "id": 3, "pty_id": 3 }
+        \\    ]
+        \\  }
+        \\}
+    ;
+
+    var pairs = try App.extractPtyIdCwdPairs(testing.allocator, json);
+    defer {
+        var it = pairs.valueIterator();
+        while (it.next()) |cwd| {
+            testing.allocator.free(cwd.*);
+        }
+        pairs.deinit();
+    }
+
+    try testing.expectEqualStrings("/tmp/project", pairs.get(1).?);
+    try testing.expect(!pairs.contains(2));
+    try testing.expect(!pairs.contains(3));
 }
 
 test "UnixSocketClient - successful connection" {

--- a/src/client.zig
+++ b/src/client.zig
@@ -1846,7 +1846,7 @@ pub const App = struct {
         try self.ui.clearState();
     }
 
-    fn cancelSessionSwitch(self: *App) void {
+    fn finishSessionSwitch(self: *App) void {
         self.session_switch_in_progress = false;
         self.state.suppress_unsolicited_pty_results = false;
         if (self.switch_target_session) |target| {
@@ -1855,13 +1855,12 @@ pub const App = struct {
         }
     }
 
+    fn cancelSessionSwitch(self: *App) void {
+        self.finishSessionSwitch();
+    }
+
     fn completeSessionSwitch(self: *App) void {
-        self.session_switch_in_progress = false;
-        self.state.suppress_unsolicited_pty_results = false;
-        if (self.switch_target_session) |target| {
-            self.allocator.free(target);
-            self.switch_target_session = null;
-        }
+        self.finishSessionSwitch();
     }
 
     fn beginSessionSwitchAttach(self: *App) !void {

--- a/src/client.zig
+++ b/src/client.zig
@@ -2162,7 +2162,6 @@ pub const App = struct {
         try self.appendSessionEnvNamed(env_array, string_allocator, session_name);
     }
 
-
     fn onSendComplete(_: *io.Loop, completion: io.Completion) anyerror!void {
         const app = completion.userdataCast(@This());
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -279,7 +279,6 @@ pub const ClientLogic = struct {
                 const attach_info = entry.value.attach;
                 if (err_val == .string and std.mem.eql(u8, err_val.string, "PTY not found")) {
                     log.info("PTY {} not found, spawning new PTY with cwd", .{attach_info.pty_id});
-                    crash_context.record("attach fallback spawn old_pty_id={d}", .{attach_info.pty_id});
                     return .{ .spawn_pty_with_cwd = .{
                         .cwd = attach_info.cwd,
                         .old_pty_id = @intCast(attach_info.pty_id),
@@ -302,8 +301,6 @@ pub const ClientLogic = struct {
                 .attach => |attach_info| {
                     state.pty_id = attach_info.pty_id;
                     state.attached = true;
-                    crash_context.setCurrentPty(@intCast(attach_info.pty_id));
-                    crash_context.record("attached existing pty_id={d}", .{attach_info.pty_id});
                     if (nonEmptyCwd(attach_info.cwd)) |c| {
                         const owned_cwd = state.allocator.dupe(u8, c) catch return .{ .attached = .{ .new_pty_id = attach_info.pty_id } };
                         state.cwd_map.put(attach_info.pty_id, owned_cwd) catch {
@@ -362,8 +359,6 @@ pub const ClientLogic = struct {
         if (id >= 0) {
             state.pty_id = id;
             state.attached = true;
-            crash_context.setCurrentPty(@intCast(id));
-            crash_context.record("attached pty_id={d} old_pty_id={?}", .{ id, old_pty_id });
             if (nonEmptyCwd(cwd)) |c| {
                 const owned_cwd = state.allocator.dupe(u8, c) catch return .{ .attached = .{ .new_pty_id = id, .old_pty_id = old_pty_id } };
                 state.cwd_map.put(id, owned_cwd) catch {
@@ -1779,10 +1774,6 @@ pub const App = struct {
         return plan.session_name;
     }
 
-    fn sessionNameForLogs(session_name: ?[]const u8) []const u8 {
-        return session_name orelse "(none)";
-    }
-
     fn finishSessionSwitch(self: *App) void {
         self.session_switch_in_progress = false;
         self.state.suppress_unsolicited_pty_results = false;
@@ -1791,20 +1782,13 @@ pub const App = struct {
     }
 
     fn cancelSessionSwitch(self: *App, reason: []const u8) void {
-        const source_session = sessionNameForLogs(self.current_session_name);
-        const target_session = sessionNameForLogs(self.preparedRestoreSessionName());
-        crash_context.record(
-            "session switch cancelled from={s} to={s} reason={s}",
-            .{ source_session, target_session, reason },
-        );
+        _ = reason;
         self.finishSessionSwitch();
     }
 
     fn completeSessionSwitch(self: *App, source_session: ?[]const u8, target_session: []const u8) void {
-        crash_context.record(
-            "session switch restore complete from={s} to={s}",
-            .{ sessionNameForLogs(source_session), target_session },
-        );
+        _ = source_session;
+        _ = target_session;
         self.finishSessionSwitch();
     }
 
@@ -1896,21 +1880,8 @@ pub const App = struct {
     }
 
     fn beginSessionSwitchAttach(self: *App) !void {
-        const source_session = sessionNameForLogs(self.current_session_name);
-        const target_session = self.preparedRestoreSessionName() orelse return error.NoPreparedRestorePlan;
-        crash_context.record(
-            "session switch detach acknowledged from={s} to={s}",
-            .{ source_session, target_session },
-        );
-        crash_context.record(
-            "session switch reset start from={s} to={s}",
-            .{ source_session, target_session },
-        );
+        _ = self.preparedRestoreSessionName() orelse return error.NoPreparedRestorePlan;
         try self.resetActiveSessionState();
-        crash_context.record(
-            "session switch reset finish from={s} to={s}",
-            .{ source_session, target_session },
-        );
         try self.scheduleRender();
         try self.applyPreparedSessionRestore();
     }
@@ -1921,8 +1892,6 @@ pub const App = struct {
             // Use the attached session name
             log.info("Setting current_session_name to: {s}", .{session_name});
             try self.setCurrentSessionName(session_name);
-            crash_context.setSessionName(self.current_session_name);
-            crash_context.record("attach session {s}", .{session_name});
             var plan = try self.preflightSessionRestore(session_name);
             var plan_stored = false;
             errdefer if (!plan_stored) plan.deinit(self.allocator);
@@ -2041,10 +2010,6 @@ pub const App = struct {
 
         if (!validity_matches) {
             log.info("pty_validity mismatch (saved={?}, current={?}), spawning fresh PTYs", .{ saved_validity, current_validity });
-            crash_context.record(
-                "session restore spawn fallback saved_validity={?} current_validity={?}",
-                .{ saved_validity, current_validity },
-            );
         }
 
         return .{
@@ -2060,7 +2025,6 @@ pub const App = struct {
     }
 
     fn preflightSessionRestore(self: *App, session_name: []const u8) !SessionRestorePlan {
-        crash_context.record("session restore preflight start {s}", .{session_name});
         const path = try self.sessionFilePath(session_name);
         defer self.allocator.free(path);
 
@@ -2070,17 +2034,9 @@ pub const App = struct {
             session_name,
             self.state.pty_validity,
         ) catch |err| {
-            crash_context.record(
-                "session restore preflight failed {s}: {s}",
-                .{ session_name, @errorName(err) },
-            );
             return err;
         };
 
-        crash_context.record(
-            "session restore preflight success {s} attach_count={d} spawn_fallback_count={d}",
-            .{ session_name, plan.attach_count, plan.spawn_fallback_count },
-        );
         return plan;
     }
 
@@ -2088,10 +2044,6 @@ pub const App = struct {
         const plan = if (self.prepared_restore_plan) |*value| value else return error.NoPreparedRestorePlan;
         std.debug.assert(plan.pty_ids.len > 0);
 
-        crash_context.record(
-            "session restore apply start {s} attach_count={d} spawn_fallback_count={d}",
-            .{ plan.session_name, plan.attach_count, plan.spawn_fallback_count },
-        );
         plan.remaining_attach_count = plan.pty_ids.len;
 
         log.info("Attaching to {} PTYs from session {s}", .{ plan.pty_ids.len, plan.session_name });
@@ -2139,13 +2091,11 @@ pub const App = struct {
             try self.ui.setStateFromJson(plan.session_json, ptyLookup, self);
         }
 
-        crash_context.record("session restore complete {s}", .{target_session});
         self.state.suppress_unsolicited_pty_results = false;
 
         if (self.session_switch_in_progress) {
             const source_session = self.current_session_name;
             try self.setCurrentSessionName(target_session);
-            crash_context.setSessionName(self.current_session_name);
             self.completeSessionSwitch(source_session, target_session);
         }
 
@@ -2609,17 +2559,7 @@ pub const App = struct {
                                 return;
                             },
                             .switch_detached => {
-                                app.beginSessionSwitchAttach() catch |err| {
-                                    crash_context.record(
-                                        "session switch apply fatal from={s} to={s} err={s}",
-                                        .{
-                                            sessionNameForLogs(app.current_session_name),
-                                            sessionNameForLogs(app.preparedRestoreSessionName()),
-                                            @errorName(err),
-                                        },
-                                    );
-                                    return err;
-                                };
+                                try app.beginSessionSwitchAttach();
                             },
                             .switch_detach_failed => {
                                 app.cancelSessionSwitch("detach rejected");
@@ -2909,30 +2849,9 @@ pub const App = struct {
             return error.SessionSwitchInProgress;
         }
 
-        const source_session = sessionNameForLogs(self.current_session_name);
-        crash_context.record(
-            "session switch requested from={s} to={s}",
-            .{ source_session, target_session },
-        );
-        crash_context.record(
-            "session switch preflight start from={s} to={s}",
-            .{ source_session, target_session },
-        );
-
-        var plan = self.preflightSessionRestore(target_session) catch |err| {
-            crash_context.record(
-                "session switch preflight failed from={s} to={s} err={s}",
-                .{ source_session, target_session, @errorName(err) },
-            );
-            return err;
-        };
+        var plan = try self.preflightSessionRestore(target_session);
         var plan_stored = false;
         errdefer if (!plan_stored) plan.deinit(self.allocator);
-
-        crash_context.record(
-            "session switch preflight success from={s} to={s} attach_count={d} spawn_fallback_count={d}",
-            .{ source_session, target_session, plan.attach_count, plan.spawn_fallback_count },
-        );
 
         if (self.current_session_name) |name| {
             log.info("Saving current session '{s}' before switch", .{name});
@@ -2950,26 +2869,12 @@ pub const App = struct {
             }
         }
 
-        if (try self.sendDetachPtysRequest(.switch_detach)) |detach_request| {
-            crash_context.record(
-                "session switch detach request sent from={s} to={s} msgid={d} ptys={d}",
-                .{ source_session, target_session, detach_request.msgid, detach_request.pty_count },
-            );
+        if (try self.sendDetachPtysRequest(.switch_detach)) |_| {
             return;
         }
 
         pre_detach_phase = false;
-        crash_context.record(
-            "session switch skipping detach from={s} to={s} reason=no-live-ptys",
-            .{ source_session, target_session },
-        );
-        self.beginSessionSwitchAttach() catch |err| {
-            crash_context.record(
-                "session switch apply fatal from={s} to={s} err={s}",
-                .{ source_session, target_session, @errorName(err) },
-            );
-            return err;
-        };
+        try self.beginSessionSwitchAttach();
     }
 
     pub fn deleteCurrentSession(self: *App) void {

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -455,6 +455,63 @@ local state = {
     pending_layout = nil,
 }
 
+local function reset_session_state()
+    if state.timer then
+        state.timer:cancel()
+        state.timer = nil
+    end
+
+    state.tabs = {}
+    state.active_tab = 1
+    state.next_tab_id = 1
+    state.focused_id = nil
+    state.zoomed_pane_id = nil
+    state.pending_command = false
+    state.pending_split = nil
+    state.pending_new_tab = false
+    state.next_split_id = 1
+
+    state.palette.visible = false
+    state.palette.selected = 1
+    state.palette.scroll_offset = 0
+    state.palette.regions = {}
+    if state.palette.input then
+        state.palette.input:clear()
+    end
+
+    state.rename.visible = false
+    if state.rename.input then
+        state.rename.input:clear()
+    end
+
+    state.rename_tab.visible = false
+    if state.rename_tab.input then
+        state.rename_tab.input:clear()
+    end
+
+    state.swap_with_index = nil
+
+    state.session_picker.visible = false
+    state.session_picker.selected = 1
+    state.session_picker.scroll_offset = 0
+    state.session_picker.sessions = {}
+    state.session_picker.regions = {}
+    state.session_picker.renaming = false
+    state.session_picker.rename_target = nil
+    if state.session_picker.input then
+        state.session_picker.input:clear()
+    end
+
+    state.tab_regions = {}
+    state.tab_close_regions = {}
+    state.hovered_tab = nil
+    state.hovered_close_tab = nil
+    state.cached_git_branch = nil
+    state.detaching = false
+    state.floating.pending = false
+    state.floating.resize_mode = false
+end
+
 local M = {}
 
 ---Forward declaration for action_handlers (defined after helper functions)
@@ -4329,6 +4386,8 @@ end
 ---@param saved? table
 ---@param pty_lookup fun(id: number): Pty?
 function M.set_state(saved, pty_lookup)
+    reset_session_state()
+
     if not saved then
         return
     end
@@ -4397,6 +4456,7 @@ function M.set_state(saved, pty_lookup)
         end
     end
 
+    update_cached_git_branch()
     prise.request_frame()
 end
 

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -103,10 +103,6 @@ local utils = require("utils")
 ---@field scroll_offset number
 ---@field regions PaletteRegion[]
 
----@class SessionSwitchState
----@field active boolean
----@field target_session? string
-
 ---@class State
 ---@field tabs Tab[]
 ---@field active_tab integer
@@ -129,7 +125,6 @@ local utils = require("utils")
 ---@field keybind_matcher? KeybindMatcher
 ---@field floating FloatingPaneState
 ---@field layout_picker LayoutPickerState
----@field session_switch SessionSwitchState
 ---@field pending_layout? table
 
 ---@class Command
@@ -182,11 +177,7 @@ local utils = require("utils")
 ---@field type "cwd_changed"
 ---@field data table
 
----@class SessionSwitchEvent
----@field type "session_switch"
----@field data { active: boolean, target_session: string }
-
----@alias Event PtyAttachEvent|PtyExitedEvent|KeyPressEvent|KeyReleaseEvent|PasteEvent|MouseEvent|WinsizeEvent|FocusInEvent|FocusOutEvent|SplitResizeEvent|CwdChangedEvent|SessionSwitchEvent
+---@alias Event PtyAttachEvent|PtyExitedEvent|KeyPressEvent|KeyReleaseEvent|PasteEvent|MouseEvent|WinsizeEvent|FocusInEvent|FocusOutEvent|SplitResizeEvent|CwdChangedEvent
 
 -- Powerline symbols
 local POWERLINE_SYMBOLS = {
@@ -459,10 +450,6 @@ local state = {
         selected = 1,
         scroll_offset = 0,
         regions = {},
-    },
-    session_switch = {
-        active = false,
-        target_session = nil,
     },
     -- Pending layout to apply (layout node definitions waiting for PTY spawns)
     pending_layout = nil,
@@ -2721,16 +2708,7 @@ end
 
 ---@param event Event
 function M.update(event)
-    if event.type == "session_switch" then
-        state.session_switch.active = event.data.active
-        if event.data.active and event.data.target_session ~= "" then
-            state.session_switch.target_session = event.data.target_session
-        else
-            state.session_switch.target_session = nil
-        end
-        prise.request_frame()
-        return
-    elseif event.type == "pty_attach" then
+    if event.type == "pty_attach" then
         prise.log.info("Lua: pty_attach received")
         ---@type Pty
         local pty = event.data.pty
@@ -4341,16 +4319,9 @@ local function build_floating()
     })
 end
 
----@return table?
-local function build_session_switch_overlay()
-    -- No overlay — let the terminals swap in place.
-    return nil
-end
-
 function M.view()
     local root = get_active_root()
-    local switch_overlay = build_session_switch_overlay()
-    if not root and not switch_overlay then
+    if not root then
         return prise.Column({
             cross_axis_align = "stretch",
             children = { prise.Text("Waiting for terminal...") },
@@ -4434,10 +4405,6 @@ function M.view()
     if floating then
         table.insert(overlay_children, floating)
     end
-    if switch_overlay then
-        table.insert(overlay_children, switch_overlay)
-    end
-
     local modal = palette or rename or rename_tab or swap_with_index or session_picker or layout_picker
     if modal then
         table.insert(overlay_children, modal)
@@ -4446,7 +4413,7 @@ function M.view()
         })
     end
 
-    if floating or switch_overlay then
+    if floating then
         return prise.Stack({
             children = overlay_children,
         })

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -550,6 +550,13 @@ local RESIZE_STEP = 0.05 -- 5% step for keyboard resize
 local PALETTE_WIDTH = 60 -- Total width of command palette
 local PALETTE_INNER_WIDTH = 56 -- Inner width (PALETTE_WIDTH - 4 for padding)
 
+---@return integer start_x
+---@return integer end_x
+local function modal_x_bounds()
+    local start_x = math.floor((state.screen_cols - PALETTE_WIDTH) / 2)
+    return start_x, start_x + PALETTE_WIDTH
+end
+
 -- Floating pane size bounds
 local FLOATING_MIN_WIDTH = 40
 local FLOATING_MAX_WIDTH = 200
@@ -1503,8 +1510,11 @@ end
 local function build_tabs_from_layout(layout, pty_queue)
     local new_tabs = {}
     local queue_idx = 1
+    ---@type number
     local new_floating_width = state.floating.width
+    ---@type number
     local new_floating_height = state.floating.height
+    ---@type boolean
     local new_floating_visible = state.floating.visible
 
     for tab_index, tab_def in ipairs(layout.tabs) do
@@ -1564,6 +1574,12 @@ local function finalize_layout(pending)
         state.pending_layout = nil
         return
     end
+    local floating_width = new_floating_width or state.floating.width
+    local floating_height = new_floating_height or state.floating.height
+    local floating_visible = new_floating_visible
+    if floating_visible == nil then
+        floating_visible = state.floating.visible
+    end
 
     -- Verify we used all PTYs
     if queue_idx ~= #pty_queue + 1 then
@@ -1579,9 +1595,9 @@ local function finalize_layout(pending)
     -- Swap in new state
     state.tabs = new_tabs
     state.next_tab_id = #new_tabs + 1
-    state.floating.width = new_floating_width
-    state.floating.height = new_floating_height
-    state.floating.visible = new_floating_visible
+    state.floating.width = floating_width
+    state.floating.height = floating_height
+    state.floating.visible = floating_visible
     state.zoomed_pane_id = nil
 
     -- Set active tab
@@ -1635,7 +1651,7 @@ local function expand_path(path)
         return expanded
     end
 
-    -- Check if it's a directory without using shell (avoids command injection)
+    -- Probe "path/." so we can recognize directories without shelling out.
     local dir_probe = io.open(expanded .. "/.", "r")
     if dir_probe then
         dir_probe:close()
@@ -3217,14 +3233,59 @@ function M.update(event)
         end
 
         if d.action == "press" and d.button == "left" then
+            -- Check if click is on session picker item
+            if
+                state.session_picker.visible
+                and not state.session_picker.renaming
+                and #state.session_picker.regions > 0
+            then
+                local click_x = math.floor(d.x)
+                local click_y = math.floor(d.y)
+                local modal_start_x, modal_end_x = modal_x_bounds()
+
+                if click_x >= modal_start_x and click_x < modal_end_x then
+                    for _, region in ipairs(state.session_picker.regions) do
+                        if click_y >= region.start_y and click_y < region.end_y then
+                            if state.session_picker.selected == region.index then
+                                execute_session_switch()
+                            else
+                                state.session_picker.selected = region.index
+                                prise.request_frame()
+                            end
+                            return
+                        end
+                    end
+                end
+            end
+
+            -- Check if click is on layout picker item
+            if state.layout_picker.visible and #state.layout_picker.regions > 0 then
+                local click_x = math.floor(d.x)
+                local click_y = math.floor(d.y)
+                local modal_start_x, modal_end_x = modal_x_bounds()
+
+                if click_x >= modal_start_x and click_x < modal_end_x then
+                    for _, region in ipairs(state.layout_picker.regions) do
+                        if click_y >= region.start_y and click_y < region.end_y then
+                            if state.layout_picker.selected == region.index then
+                                execute_selected_layout()
+                            else
+                                state.layout_picker.selected = region.index
+                                prise.request_frame()
+                            end
+                            return
+                        end
+                    end
+                end
+            end
+
             -- Check if click is on command palette item
             if state.palette.visible and #state.palette.regions > 0 then
                 -- Convert float coords to integer cell positions
                 local click_x = math.floor(d.x)
                 local click_y = math.floor(d.y)
 
-                local palette_start_x = math.floor((state.screen_cols - PALETTE_WIDTH) / 2)
-                local palette_end_x = palette_start_x + PALETTE_WIDTH
+                local palette_start_x, palette_end_x = modal_x_bounds()
 
                 if click_x >= palette_start_x and click_x < palette_end_x then
                     for _, region in ipairs(state.palette.regions) do

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -103,6 +103,10 @@ local utils = require("utils")
 ---@field scroll_offset number
 ---@field regions PaletteRegion[]
 
+---@class SessionSwitchState
+---@field active boolean
+---@field target_session? string
+
 ---@class State
 ---@field tabs Tab[]
 ---@field active_tab integer
@@ -125,6 +129,7 @@ local utils = require("utils")
 ---@field keybind_matcher? KeybindMatcher
 ---@field floating FloatingPaneState
 ---@field layout_picker LayoutPickerState
+---@field session_switch SessionSwitchState
 ---@field pending_layout? table
 
 ---@class Command
@@ -177,7 +182,11 @@ local utils = require("utils")
 ---@field type "cwd_changed"
 ---@field data table
 
----@alias Event PtyAttachEvent|PtyExitedEvent|KeyPressEvent|KeyReleaseEvent|PasteEvent|MouseEvent|WinsizeEvent|FocusInEvent|FocusOutEvent|SplitResizeEvent|CwdChangedEvent
+---@class SessionSwitchEvent
+---@field type "session_switch"
+---@field data { active: boolean, target_session: string }
+
+---@alias Event PtyAttachEvent|PtyExitedEvent|KeyPressEvent|KeyReleaseEvent|PasteEvent|MouseEvent|WinsizeEvent|FocusInEvent|FocusOutEvent|SplitResizeEvent|CwdChangedEvent|SessionSwitchEvent
 
 -- Powerline symbols
 local POWERLINE_SYMBOLS = {
@@ -451,6 +460,10 @@ local state = {
         scroll_offset = 0,
         regions = {},
     },
+    session_switch = {
+        active = false,
+        target_session = nil,
+    },
     -- Pending layout to apply (layout node definitions waiting for PTY spawns)
     pending_layout = nil,
 }
@@ -502,12 +515,18 @@ local function reset_session_state()
         state.session_picker.input:clear()
     end
 
+    state.layout_picker.visible = false
+    state.layout_picker.selected = 1
+    state.layout_picker.scroll_offset = 0
+    state.layout_picker.regions = {}
+
     state.tab_regions = {}
     state.tab_close_regions = {}
     state.hovered_tab = nil
     state.hovered_close_tab = nil
     state.cached_git_branch = nil
     state.detaching = false
+    state.floating.visible = false
     state.floating.pending = false
     state.floating.resize_mode = false
 end
@@ -2702,7 +2721,16 @@ end
 
 ---@param event Event
 function M.update(event)
-    if event.type == "pty_attach" then
+    if event.type == "session_switch" then
+        state.session_switch.active = event.data.active
+        if event.data.active and event.data.target_session ~= "" then
+            state.session_switch.target_session = event.data.target_session
+        else
+            state.session_switch.target_session = nil
+        end
+        prise.request_frame()
+        return
+    elseif event.type == "pty_attach" then
         prise.log.info("Lua: pty_attach received")
         ---@type Pty
         local pty = event.data.pty
@@ -4313,9 +4341,42 @@ local function build_floating()
     })
 end
 
+---@return table?
+local function build_session_switch_overlay()
+    if not state.session_switch.active then
+        return nil
+    end
+
+    local target = state.session_switch.target_session or "session"
+    return prise.Positioned({
+        anchor = "center",
+        focus = true,
+        child = prise.Box({
+            border = config.borders.style,
+            style = { bg = THEME.bg1, fg = THEME.fg_bright },
+            child = prise.Padding({
+                top = 1,
+                bottom = 1,
+                left = 2,
+                right = 2,
+                child = prise.Column({
+                    cross_axis_align = "stretch",
+                    children = {
+                        prise.Text({
+                            text = "Switching to " .. target .. "...",
+                            style = { fg = THEME.fg_bright, bg = THEME.bg1 },
+                        }),
+                    },
+                }),
+            }),
+        }),
+    })
+end
+
 function M.view()
     local root = get_active_root()
-    if not root then
+    local switch_overlay = build_session_switch_overlay()
+    if not root and not switch_overlay then
         return prise.Column({
             cross_axis_align = "stretch",
             children = { prise.Text("Waiting for terminal...") },
@@ -4335,9 +4396,6 @@ function M.view()
     local layout_picker = build_layout_picker()
     local floating = build_floating()
     local tab_bar = build_tab_bar()
-    prise.log.debug("view: palette.visible=" .. tostring(state.palette.visible))
-
-    -- When zoomed, render only the zoomed pane
     local tab = get_active_tab()
     local floating_visible = tab and tab.floating and tab.floating.visible
     local overlay_visible = state.palette.visible
@@ -4347,8 +4405,16 @@ function M.view()
         or state.session_picker.visible
         or state.layout_picker.visible
         or floating_visible
+        or state.session_switch.active
+    prise.log.debug("view: palette.visible=" .. tostring(state.palette.visible))
+
     local content
-    if state.zoomed_pane_id then
+    if not root then
+        content = prise.Column({
+            cross_axis_align = "stretch",
+            children = {},
+        })
+    elseif state.zoomed_pane_id then
         local path = find_node_path(root, state.zoomed_pane_id)
         if path then
             local pane = path[#path]
@@ -4357,12 +4423,10 @@ function M.view()
                 focus = not overlay_visible,
             })
 
-            -- Apply borders to zoomed pane if enabled and show_single_pane is true
-            -- (zoomed pane is a temporary single-pane view)
             if config.borders.enabled and config.borders.show_single_pane then
                 content = prise.Box({
                     border = config.borders.style,
-                    style = { fg = config.borders.focused_color }, -- Zoomed pane is always focused
+                    style = { fg = config.borders.focused_color },
                     child = terminal,
                 })
             else
@@ -4397,6 +4461,9 @@ function M.view()
     if floating then
         table.insert(overlay_children, floating)
     end
+    if switch_overlay then
+        table.insert(overlay_children, switch_overlay)
+    end
 
     local modal = palette or rename or rename_tab or swap_with_index or session_picker or layout_picker
     if modal then
@@ -4406,8 +4473,7 @@ function M.view()
         })
     end
 
-    -- If we only have floating pane (no modal), use Stack if floating exists
-    if floating then
+    if floating or switch_overlay then
         return prise.Stack({
             children = overlay_children,
         })

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -4343,34 +4343,8 @@ end
 
 ---@return table?
 local function build_session_switch_overlay()
-    if not state.session_switch.active then
-        return nil
-    end
-
-    local target = state.session_switch.target_session or "session"
-    return prise.Positioned({
-        anchor = "center",
-        focus = true,
-        child = prise.Box({
-            border = config.borders.style,
-            style = { bg = THEME.bg1, fg = THEME.fg_bright },
-            child = prise.Padding({
-                top = 1,
-                bottom = 1,
-                left = 2,
-                right = 2,
-                child = prise.Column({
-                    cross_axis_align = "stretch",
-                    children = {
-                        prise.Text({
-                            text = "Switching to " .. target .. "...",
-                            style = { fg = THEME.fg_bright, bg = THEME.bg1 },
-                        }),
-                    },
-                }),
-            }),
-        }),
-    })
+    -- No overlay — let the terminals swap in place.
+    return nil
 end
 
 function M.view()
@@ -4405,7 +4379,6 @@ function M.view()
         or state.session_picker.visible
         or state.layout_picker.visible
         or floating_visible
-        or state.session_switch.active
     prise.log.debug("view: palette.visible=" .. tostring(state.palette.visible))
 
     local content

--- a/src/lua/tiling_test.lua
+++ b/src/lua/tiling_test.lua
@@ -157,29 +157,6 @@ assert(panes[1].id == 1, "collect_panes: nested first")
 assert(panes[2].id == 2, "collect_panes: nested second")
 assert(panes[3].id == 3, "collect_panes: nested third")
 
--- === session switch overlay state ===
-
-tiling.update({ type = "session_switch", data = { active = true, target_session = "target" } })
-local switch_state = t.get_state()
-switch_state.layout_picker.visible = true
-switch_state.layout_picker.selected = 2
-
-tiling.set_state(nil, function()
-    return nil
-end)
-switch_state = t.get_state()
-assert(switch_state.layout_picker.visible == false, "set_state(nil): clears layout picker")
-assert(switch_state.session_switch.active == true, "set_state(nil): preserves session switch active state")
-assert(switch_state.session_switch.target_session == "target", "set_state(nil): preserves session switch target")
-
-local switch_view = tiling.view()
-assert(switch_view.type == "stack", "view: session switch with no root renders overlay stack")
-
-tiling.update({ type = "session_switch", data = { active = false, target_session = "" } })
-switch_state = t.get_state()
-assert(switch_state.session_switch.active == false, "session switch: clears active flag")
-assert(switch_state.session_switch.target_session == nil, "session switch: clears target")
-
 -- Test: collect_tab_panes includes floating pane
 local floating_pane = mock_pane(9)
 local tab_with_floating = mock_tab(split_node, floating_pane)

--- a/src/lua/tiling_test.lua
+++ b/src/lua/tiling_test.lua
@@ -80,10 +80,21 @@ package.loaded["prise"] = {
     end,
     log = { debug = function() end },
     request_frame = function() end,
+    set_timeout = function(_, _)
+        return {
+            cancel = function() end,
+        }
+    end,
     save = function() end,
     exit = function() end,
     get_session_name = function()
         return "test"
+    end,
+    get_git_branch = function()
+        return nil
+    end,
+    get_time = function()
+        return "12:00"
     end,
 }
 
@@ -145,6 +156,37 @@ assert(#panes == 3, "collect_panes: nested splits")
 assert(panes[1].id == 1, "collect_panes: nested first")
 assert(panes[2].id == 2, "collect_panes: nested second")
 assert(panes[3].id == 3, "collect_panes: nested third")
+
+-- === session switch overlay state ===
+
+tiling.update({ type = "session_switch", data = { active = true, target_session = "target" } })
+local switch_state = t.get_state()
+switch_state.layout_picker.visible = true
+switch_state.layout_picker.selected = 2
+
+tiling.set_state(nil, function()
+    return nil
+end)
+switch_state = t.get_state()
+assert(switch_state.layout_picker.visible == false, "set_state(nil): clears layout picker")
+assert(switch_state.session_switch.active == true, "set_state(nil): preserves session switch active state")
+assert(switch_state.session_switch.target_session == "target", "set_state(nil): preserves session switch target")
+
+local switch_view = tiling.view()
+assert(switch_view.type == "stack", "view: session switch with no root renders overlay stack")
+
+tiling.update({ type = "session_switch", data = { active = false, target_session = "" } })
+switch_state = t.get_state()
+assert(switch_state.session_switch.active == false, "session switch: clears active flag")
+assert(switch_state.session_switch.target_session == nil, "session switch: clears target")
+
+-- Test: collect_tab_panes includes floating pane
+local floating_pane = mock_pane(9)
+local tab_with_floating = mock_tab(split_node, floating_pane)
+panes = t.collect_tab_panes(tab_with_floating)
+assert(#panes == 3, "collect_tab_panes: includes floating pane")
+assert(panes[3].id == 9, "collect_tab_panes: floating pane last")
+
 
 -- === find_node_path ===
 

--- a/src/lua/tiling_test.lua
+++ b/src/lua/tiling_test.lua
@@ -157,14 +157,6 @@ assert(panes[1].id == 1, "collect_panes: nested first")
 assert(panes[2].id == 2, "collect_panes: nested second")
 assert(panes[3].id == 3, "collect_panes: nested third")
 
--- Test: collect_tab_panes includes floating pane
-local floating_pane = mock_pane(9)
-local tab_with_floating = mock_tab(split_node, floating_pane)
-panes = t.collect_tab_panes(tab_with_floating)
-assert(#panes == 3, "collect_tab_panes: includes floating pane")
-assert(panes[3].id == 9, "collect_tab_panes: floating pane last")
-
-
 -- === find_node_path ===
 
 -- Test: find_node_path with nil

--- a/src/lua_event.zig
+++ b/src/lua_event.zig
@@ -41,6 +41,17 @@ pub const CwdChangedInfo = struct {
     cwd: []const u8,
 };
 
+pub const RenameTabInfo = struct {
+    pty_id: u32,
+    title: []const u8,
+};
+
+pub const SessionSwitchInfo = struct {
+    active: bool,
+    target_session: []const u8,
+};
+
+
 pub const Event = union(enum) {
     vaxis: vaxis.Event,
     mouse: MouseEvent,
@@ -49,6 +60,8 @@ pub const Event = union(enum) {
     pty_attach: PtyAttachInfo,
     pty_exited: PtyExitedInfo,
     cwd_changed: CwdChangedInfo,
+    rename_tab: RenameTabInfo,
+    session_switch: SessionSwitchInfo,
     init: void,
 };
 
@@ -106,6 +119,8 @@ pub fn pushEvent(lua: *ziglua.Lua, event: Event) !void {
         .pty_attach => |info| pushPtyAttachEvent(lua, info),
         .pty_exited => |info| pushPtyExitedEvent(lua, info),
         .cwd_changed => |info| pushCwdChangedEvent(lua, info),
+        .rename_tab => |info| pushRenameTabEvent(lua, info),
+        .session_switch => |info| pushSessionSwitchEvent(lua, info),
         .paste => |data| pushPasteEvent(lua, data),
         .split_resize => |sr| pushSplitResizeEvent(lua, sr),
         .mouse => |m| pushMouseEvent(lua, m),
@@ -172,6 +187,31 @@ fn pushCwdChangedEvent(lua: *ziglua.Lua, info: CwdChangedInfo) void {
     lua.setField(-2, "cwd");
     lua.setField(-2, "data");
 }
+
+fn pushRenameTabEvent(lua: *ziglua.Lua, info: RenameTabInfo) void {
+    _ = lua.pushString("rename_tab");
+    lua.setField(-2, "type");
+
+    lua.createTable(0, 2);
+    lua.pushInteger(@intCast(info.pty_id));
+    lua.setField(-2, "pty_id");
+    _ = lua.pushString(info.title);
+    lua.setField(-2, "title");
+    lua.setField(-2, "data");
+}
+
+fn pushSessionSwitchEvent(lua: *ziglua.Lua, info: SessionSwitchInfo) void {
+    _ = lua.pushString("session_switch");
+    lua.setField(-2, "type");
+
+    lua.createTable(0, 2);
+    lua.pushBoolean(info.active);
+    lua.setField(-2, "active");
+    _ = lua.pushString(info.target_session);
+    lua.setField(-2, "target_session");
+    lua.setField(-2, "data");
+}
+
 
 fn pushPasteEvent(lua: *ziglua.Lua, data: []const u8) void {
     _ = lua.pushString("paste");

--- a/src/lua_event.zig
+++ b/src/lua_event.zig
@@ -46,12 +46,6 @@ pub const RenameTabInfo = struct {
     title: []const u8,
 };
 
-pub const SessionSwitchInfo = struct {
-    active: bool,
-    target_session: []const u8,
-};
-
-
 pub const Event = union(enum) {
     vaxis: vaxis.Event,
     mouse: MouseEvent,
@@ -61,7 +55,6 @@ pub const Event = union(enum) {
     pty_exited: PtyExitedInfo,
     cwd_changed: CwdChangedInfo,
     rename_tab: RenameTabInfo,
-    session_switch: SessionSwitchInfo,
     init: void,
 };
 
@@ -120,7 +113,6 @@ pub fn pushEvent(lua: *ziglua.Lua, event: Event) !void {
         .pty_exited => |info| pushPtyExitedEvent(lua, info),
         .cwd_changed => |info| pushCwdChangedEvent(lua, info),
         .rename_tab => |info| pushRenameTabEvent(lua, info),
-        .session_switch => |info| pushSessionSwitchEvent(lua, info),
         .paste => |data| pushPasteEvent(lua, data),
         .split_resize => |sr| pushSplitResizeEvent(lua, sr),
         .mouse => |m| pushMouseEvent(lua, m),
@@ -199,19 +191,6 @@ fn pushRenameTabEvent(lua: *ziglua.Lua, info: RenameTabInfo) void {
     lua.setField(-2, "title");
     lua.setField(-2, "data");
 }
-
-fn pushSessionSwitchEvent(lua: *ziglua.Lua, info: SessionSwitchInfo) void {
-    _ = lua.pushString("session_switch");
-    lua.setField(-2, "type");
-
-    lua.createTable(0, 2);
-    lua.pushBoolean(info.active);
-    lua.setField(-2, "active");
-    _ = lua.pushString(info.target_session);
-    lua.setField(-2, "target_session");
-    lua.setField(-2, "data");
-}
-
 
 fn pushPasteEvent(lua: *ziglua.Lua, data: []const u8) void {
     _ = lua.pushString("paste");

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -1155,6 +1155,26 @@ pub const UI = struct {
         self.allocator.destroy(lookup_ctx);
     }
 
+    pub fn clearState(self: *UI) !void {
+        _ = self.lua.getField(ziglua.registry_index, "prise_ui");
+        defer self.lua.pop(1);
+
+        _ = self.lua.getField(-1, "set_state");
+        if (self.lua.typeOf(-1) != .function) {
+            return error.NoSetStateFunction;
+        }
+
+        self.lua.pushNil();
+        self.lua.pushNil();
+
+        self.lua.protectedCall(.{ .args = 2, .results = 0, .msg_handler = 0 }) catch |err| {
+            const msg = self.lua.toString(-1) catch "Unknown Lua error";
+            log.err("Lua clear_state error: {s}", .{msg});
+            self.lua.pop(1);
+            return err;
+        };
+    }
+
     fn ptyLookupWrapper(lua: *ziglua.Lua) i32 {
         const LookupCtx = struct {
             ctx: *anyopaque,


### PR DESCRIPTION
Session switching currently execs a whole new prise process — drops alt-screen, flashes the shell, reinits everything. Kinda rough.

This replaces that with an in-process detach → reset → reattach cycle. The client stays alive, stays in alt-screen, swaps its guts out.

**The flow:**

1. Preflight the target session file before touching anything — if it's missing or corrupt, bail without disrupting the current session
2. Detach current PTYs from the server (tagged `switch_detach` so the client knows not to exit)
3. Tear down surfaces, timers, Lua state
4. Reattach target PTYs (or spawn fresh ones if the server rebooted and validity doesn't match)
5. Restore the saved tab/split/floating layout from JSON

Input is suppressed during the switch and stale PTY notifications are ignored so nothing leaks across sessions.

Also fixes empty cwd handling — `""` was being treated as a real directory and killing child shells on fallback spawn.

**Tested:**
- Zig: switch detach, attach fallback with PTY ID remap, unsolicited result suppression, empty cwd filtering, restore plan construction, preflight failure safety
- Lua: state reset on `set_state(nil)`, floating pane collection
- Manual: Alt+7/Alt+8 session cycling, server restart recovery, nonexistent session error path