### PR TITLE
handle paste events in modal dialogs

### DIFF
--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -3102,6 +3102,12 @@ function M.update(event)
         elseif state.rename.visible then
             state.rename.input:insert(text_sanitized)
             prise.request_frame()
+        elseif state.session_picker.visible then
+            state.session_picker.input:insert(text_sanitized)
+            prise.request_frame()
+        elseif state.swap_with_index and state.swap_with_index.visible then
+            state.swap_with_index.input:insert(text_sanitized)
+            prise.request_frame()
         else
             local pty = get_visible_floating_pty() or get_focused_pty()
             if pty then

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -3091,11 +3091,16 @@ function M.update(event)
             pty:send_key(data)
         end
     elseif event.type == "paste" then
+        local text_sanitized = event.data.text:gsub("[\r\n\t]", " ")
         if state.palette.visible then
-            -- Insert into command palette, replacing newlines/tabs with spaces
-            local text = event.data.text:gsub("[\r\n\t]", " ")
-            state.palette.input:insert(text)
+            state.palette.input:insert(text_sanitized)
             state.palette.selected = 1
+            prise.request_frame()
+        elseif state.rename_tab.visible then
+            state.rename_tab.input:insert(text_sanitized)
+            prise.request_frame()
+        elseif state.rename.visible then
+            state.rename.input:insert(text_sanitized)
             prise.request_frame()
         else
             local pty = get_visible_floating_pty() or get_focused_pty()


### PR DESCRIPTION
Paste in a modal dialog goes straight to the PTY behind it. The built-in
command palette handles paste correctly — user dialogs don't. Rename tab,
rename session, session picker, swap index: all four drop paste on the floor.

Hoist the newline/tab sanitization above the dialog dispatch and route the
cleaned text into whichever input is active. Same gsub the palette already
uses, now covering every modal.

One file, 14 lines.

> This fix is part of a [multi-branch fork](https://gist.github.com/possibilities/766f3f13e61c90a18674a95679db08b8) adding programmable capabilities to prise. See the [capabilities guide](https://gist.github.com/possibilities/13d77bb418ca1498d5bfd6b1500eb968) for the full picture.