### PR TITLE
clean exit when attaching to missing session

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -297,7 +297,20 @@ fn handleSessionCommand(allocator: std.mem.Allocator, args: *std.process.ArgIter
         const session = if (args.next()) |s|
             try allocator.dupe(u8, s)
         else
-            try findMostRecentSession(allocator);
+            findMostRecentSession(allocator) catch |err| {
+                if (err == error.NoSessionsFound) {
+                    std.fs.File.stderr().writeAll("No sessions found\n") catch {};
+                    return null;
+                }
+                return err;
+            };
+        if (!sessionExists(allocator, session)) {
+            var buf: [256]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "Session '{s}' not found\n", .{session}) catch return null;
+            std.fs.File.stderr().writeAll(msg) catch {};
+            allocator.free(session);
+            return null;
+        }
         return .{ .attach_session = session };
     } else if (std.mem.eql(u8, subcmd, "list")) {
         try listSessions(allocator);


### PR DESCRIPTION
`prise session attach <name>` crashes if the session doesn't exist.
`handleSessionCommand` hits an unhandled `NoSessionsFound` error from
`findMostRecentSession`, and `sessionExists` was never called for named
sessions.

Print a message to stderr and return nil instead of unwinding.

One file, 14 lines.

> Part of a [multi-branch fork](https://gist.github.com/possibilities/766f3f13e61c90a18674a95679db08b8) adding programmable capabilities to prise. [Capabilities guide](https://gist.github.com/possibilities/13d77bb418ca1498d5bfd6b1500eb968).