### PR TITLE
include current session in list_sessions before autosave

### DIFF
--- a/docs/prise.7.md
+++ b/docs/prise.7.md
@@ -48,6 +48,9 @@ client connections. Sessions are stored in *~/.local/share/prise/sessions/*.
 **prise session rename** *old* *new*
 :   Rename a session
 
+Sessions are visible to Lua code (via **prise.list_sessions()**) immediately
+upon creation, before the autosave timer writes them to disk.
+
 # SERVICE CONFIGURATION
 
 The server should run continuously in the background. Prise provides service

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -634,6 +634,29 @@ pub const UI = struct {
             };
         }
 
+        // Ensure the current session is included even if not yet saved to disk.
+        // New sessions aren't written until the autosave timer fires (1s delay),
+        // but get_session_name reads from memory and is always current.
+        if (ui.get_session_name_callback) |cb| {
+            if (cb(ui.get_session_name_ctx)) |current| {
+                var found = false;
+                for (names.items) |name| {
+                    if (std.mem.eql(u8, name, current)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    const duped = ui.allocator.dupe(u8, current) catch null;
+                    if (duped) |d| {
+                        names.append(ui.allocator, d) catch {
+                            ui.allocator.free(d);
+                        };
+                    }
+                }
+            }
+        }
+
         lua.createTable(@intCast(names.items.len), 0);
         for (names.items, 1..) |name, idx| {
             _ = lua.pushString(name);


### PR DESCRIPTION
`prise.list_sessions()` reads session files from disk, but the current
session hasn't been written yet — 1-second autosave delay. First call
after session creation returns a list that's missing the session you're
sitting in.

Check `get_session_name` (reads from memory, always current) and append
if not already present in the file-based list.

Two files, 26 lines — `ui.zig` for the fix, `prise.7.md` for docs.

> Part of a [multi-branch fork](https://gist.github.com/possibilities/766f3f13e61c90a18674a95679db08b8) adding programmable capabilities to prise. [Capabilities guide](https://gist.github.com/possibilities/13d77bb418ca1498d5bfd6b1500eb968).