### PR TITLE
fix uppercase shifted letter keys in extractKey

### DIFF
--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -33,6 +33,11 @@ const Matcher = keybind_matcher.Matcher;
 const Key = key_string.Key;
 const Action = action_mod.Action;
 
+// File-scope buffer for extractKey to uppercase a shifted letter key.
+// Safe: Lua event handling is single-threaded, and the returned Key is
+// consumed by handleKey (via keyToId) before the next call to extractKey.
+var extract_key_upper: [1:0]u8 = .{0};
+
 const MatcherHandle = struct {
     trie: *Trie,
     matcher: Matcher,
@@ -330,12 +335,20 @@ fn extractKey(lua: *ziglua.Lua, index: i32) !Key {
     // Don't include shift modifier when matching on generated text.
     // Shift is consumed by character generation (e.g., Shift+Comma produces '<').
     // Only strip shift for single printable characters - keep it for special keys like <S-Enter>.
+    // When the key is a lowercase letter but shift is held (e.g., Alt suppressed text
+    // generation so vaxis reports the unshifted codepoint), uppercase it to reflect
+    // what shift would have produced.
+    var effective_key = key_str;
     if (shift and key_str.len == 1 and key_str[0] >= 0x20 and key_str[0] < 0x7F) {
+        if (key_str[0] >= 'a' and key_str[0] <= 'z') {
+            extract_key_upper[0] = key_str[0] - 0x20;
+            effective_key = extract_key_upper[0..1];
+        }
         shift = false;
     }
 
     return Key{
-        .key = key_str,
+        .key = effective_key,
         .ctrl = ctrl,
         .alt = alt,
         .shift = shift,

--- a/src/keybind_matcher.zig
+++ b/src/keybind_matcher.zig
@@ -217,3 +217,26 @@ test "key string preserved in result" {
     try std.testing.expect(result == .action);
     try std.testing.expectEqualStrings("<D-k>v", result.action.key_string.?);
 }
+
+test "uppercase alt bindings stay distinct from lowercase alt bindings" {
+    var compiler = keybind_compiler.Compiler.init(std.testing.allocator);
+    defer compiler.deinit();
+
+    const bindings = [_]keybind_compiler.Keybind{
+        .{ .key_string = "<A-h>", .action = .focus_left },
+        .{ .key_string = "<A-H>", .action = .focus_right },
+    };
+
+    var trie = try compiler.compile(&bindings);
+    defer trie.deinit();
+
+    var matcher = Matcher.init(&trie);
+
+    const lower = matcher.handleKey(.{ .key = "h", .alt = true });
+    try std.testing.expect(lower == .action);
+    try std.testing.expectEqual(Action.focus_left, lower.action.action);
+
+    const upper = matcher.handleKey(.{ .key = "H", .alt = true });
+    try std.testing.expect(upper == .action);
+    try std.testing.expectEqual(Action.focus_right, upper.action.action);
+}


### PR DESCRIPTION
When Alt suppresses text generation, vaxis reports the unshifted codepoint.
Alt+Shift+H produces key='h' with shift=true. extractKey strips shift for
single printable chars but doesn't uppercase the letter first — so
Alt+Shift+H matches the same trie entry as Alt+H.

Fix: uppercase the letter before stripping shift. Alt+Shift+H now produces
key='H' (shift=false), matching <A-H> correctly.

Test added: verify <A-h> and <A-H> bind to different actions.