### PR TITLE
use remapped PTY ID in session restore userdata

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -2877,6 +2877,7 @@ pub const App = struct {
         const surface = self.surfaces.get(lookup_id) orelse return null;
 
         return .{
+            .pty_id = lookup_id,
             .surface = surface,
             .app = self,
             .send_key_fn = struct {

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -1131,6 +1131,8 @@ pub const UI = struct {
     }
 
     pub const PtyLookupResult = struct {
+        /// Actual server-side PTY ID (may differ from saved ID after remap)
+        pty_id: u32,
         surface: *Surface,
         app: *anyopaque,
         send_key_fn: *const fn (app: *anyopaque, id: u32, key: lua_event.KeyData) anyerror!void,
@@ -1189,7 +1191,9 @@ pub const UI = struct {
         const result = lookup_ctx.lookup_fn(lookup_ctx.ctx, id);
 
         if (result) |r| {
-            lua_event.pushPtyUserdata(lua, id, r.surface, r.app, r.send_key_fn, r.send_mouse_fn, r.send_paste_fn, r.set_focus_fn, r.close_fn, r.cwd_fn, r.copy_selection_fn, r.cell_size_fn) catch {
+            // Use the actual server-side PTY ID (may differ from saved ID
+            // after remap when a PTY was respawned during session restore)
+            lua_event.pushPtyUserdata(lua, r.pty_id, r.surface, r.app, r.send_key_fn, r.send_mouse_fn, r.send_paste_fn, r.set_focus_fn, r.close_fn, r.cwd_fn, r.copy_selection_fn, r.cell_size_fn) catch {
                 lua.pushNil();
             };
         } else {


### PR DESCRIPTION
After server restart, PTY IDs are remapped. `pushPtyUserdata` receives the
original stale ID instead of the remapped one from `ptyLookup`. Keyboard
input is silently dropped because the Lua userdata references a dead PTY.

Fix: thread the remapped `lookup_id` through `PtyLookupResult` and pass it
to `pushPtyUserdata`.