### PR TITLE
fix deserialized pane ID to use pty:id() after session restore

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -2273,7 +2273,7 @@ pub const App = struct {
                                 app.ui.update(.{ .pty_exited = .{ .id = info.pty_id, .status = info.status } }) catch |err| {
                                     log.err("Failed to update UI with pty_exited: {}", .{err});
                                 };
-                                // Delete session file when last PTY exits (if quit wasn't already called)
+                                // Handle last PTY exit (if quit wasn't already called)
                                 if (app.surfaces.count() == 0 and !app.state.should_quit) {
                                     // Cancel autosave timer to prevent it from recreating the file
                                     if (app.autosave_timer) |*task| {
@@ -2281,6 +2281,15 @@ pub const App = struct {
                                         app.autosave_timer = null;
                                     }
                                     app.deleteCurrentSession();
+                                    // Safety: force quit when no surfaces remain
+                                    // to prevent frozen client if Lua didn't trigger exit
+                                    log.info("No surfaces remaining — forcing quit", .{});
+                                    app.state.should_quit = true;
+                                    if (app.connected) {
+                                        posix.close(app.fd);
+                                        app.connected = false;
+                                    }
+                                    app.vx.deviceStatusReport(app.tty.writer()) catch {};
                                 }
                             },
                             .cwd_changed => |info| {

--- a/src/client.zig
+++ b/src/client.zig
@@ -666,6 +666,11 @@ pub const App = struct {
     // Auto-save timer for debouncing
     autosave_timer: ?io.Task = null,
 
+    /// Set by pty_exited handler when the last surface is gone. Acted on
+    /// outside any task callback to avoid self-cancelling the recv_task
+    /// whose completion we would otherwise be running in.
+    pending_force_quit: bool = false,
+
     pub const PendingColorQuery = struct {
         pty_id: u32,
         target: ServerAction.ColorQueryTarget.Target,
@@ -810,6 +815,41 @@ pub const App = struct {
 
         posix.close(self.pipe_read_fd);
         posix.close(self.pipe_write_fd);
+    }
+
+    /// Runs the deferred force-quit work outside any task callback.
+    /// Called from the top of onPipeRead after the pty_exited handler set
+    /// pending_force_quit — we're no longer on the recv_task's completion
+    /// stack, so cancelling it is safe.
+    fn forceQuitIfPending(self: *App) void {
+        if (!self.pending_force_quit) return;
+        self.pending_force_quit = false;
+        if (self.state.should_quit) return;
+
+        log.info("forceQuitIfPending: no surfaces remaining — forcing quit", .{});
+        self.state.should_quit = true;
+
+        if (self.recv_task) |*task| {
+            if (self.io_loop) |loop| task.cancel(loop) catch {};
+            self.recv_task = null;
+        }
+        if (self.render_timer) |*task| {
+            if (self.io_loop) |loop| task.cancel(loop) catch {};
+            self.render_timer = null;
+        }
+        if (self.pipe_read_task) |*task| {
+            if (self.io_loop) |loop| task.cancel(loop) catch {};
+            self.pipe_read_task = null;
+        }
+        if (self.send_task) |*task| {
+            if (self.io_loop) |loop| task.cancel(loop) catch {};
+            self.send_task = null;
+        }
+        if (self.connected) {
+            posix.close(self.fd);
+            self.connected = false;
+        }
+        self.vx.deviceStatusReport(self.tty.writer()) catch {};
     }
 
     pub fn setup(self: *App, loop: *io.Loop) !void {
@@ -1019,6 +1059,11 @@ pub const App = struct {
 
     fn onPipeRead(l: *io.Loop, completion: io.Completion) anyerror!void {
         const app = completion.userdataCast(@This());
+
+        // Act on any deferred force-quit request from the pty_exited handler.
+        // Safe here because we're on onPipeRead's stack, not recv_task's.
+        app.forceQuitIfPending();
+        if (app.state.should_quit) return;
 
         switch (completion.result) {
             .read => |bytes_read| {
@@ -2273,42 +2318,19 @@ pub const App = struct {
                                 app.ui.update(.{ .pty_exited = .{ .id = info.pty_id, .status = info.status } }) catch |err| {
                                     log.err("Failed to update UI with pty_exited: {}", .{err});
                                 };
-                                // Handle last PTY exit (if quit wasn't already called)
+                                // Handle last PTY exit (if quit wasn't already called).
+                                // Defer the actual cleanup out of onRecv — we're currently
+                                // running on recv_task's completion stack, and cancelling it
+                                // from here corrupts the io.Loop's task state. forceQuitIfPending
+                                // runs from onPipeRead instead, which is a different task.
                                 if (app.surfaces.count() == 0 and !app.state.should_quit) {
-                                    // Cancel autosave timer to prevent it from recreating the file
                                     if (app.autosave_timer) |*task| {
                                         if (app.io_loop) |loop| task.cancel(loop) catch {};
                                         app.autosave_timer = null;
                                     }
                                     app.deleteCurrentSession();
-                                    // Safety: force quit when no surfaces remain
-                                    // to prevent frozen client if Lua didn't trigger exit
-                                    log.info("No surfaces remaining — forcing quit", .{});
-                                    app.state.should_quit = true;
-                                    // Cancel pending tasks before closing fd to prevent
-                                    // completions firing on a closed/recycled descriptor.
-                                    // Capture as `loop` to avoid shadowing onRecv's `l` parameter.
-                                    if (app.recv_task) |*task| {
-                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
-                                        app.recv_task = null;
-                                    }
-                                    if (app.render_timer) |*task| {
-                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
-                                        app.render_timer = null;
-                                    }
-                                    if (app.pipe_read_task) |*task| {
-                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
-                                        app.pipe_read_task = null;
-                                    }
-                                    if (app.send_task) |*task| {
-                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
-                                        app.send_task = null;
-                                    }
-                                    if (app.connected) {
-                                        posix.close(app.fd);
-                                        app.connected = false;
-                                    }
-                                    app.vx.deviceStatusReport(app.tty.writer()) catch {};
+                                    log.info("No surfaces remaining — deferring force quit", .{});
+                                    app.pending_force_quit = true;
                                 }
                             },
                             .cwd_changed => |info| {

--- a/src/client.zig
+++ b/src/client.zig
@@ -2285,6 +2285,25 @@ pub const App = struct {
                                     // to prevent frozen client if Lua didn't trigger exit
                                     log.info("No surfaces remaining — forcing quit", .{});
                                     app.state.should_quit = true;
+                                    // Cancel pending tasks before closing fd to prevent
+                                    // completions firing on a closed/recycled descriptor.
+                                    // Capture as `loop` to avoid shadowing onRecv's `l` parameter.
+                                    if (app.recv_task) |*task| {
+                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
+                                        app.recv_task = null;
+                                    }
+                                    if (app.render_timer) |*task| {
+                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
+                                        app.render_timer = null;
+                                    }
+                                    if (app.pipe_read_task) |*task| {
+                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
+                                        app.pipe_read_task = null;
+                                    }
+                                    if (app.send_task) |*task| {
+                                        if (app.io_loop) |loop| task.cancel(loop) catch {};
+                                        app.send_task = null;
+                                    }
                                     if (app.connected) {
                                         posix.close(app.fd);
                                         app.connected = false;

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -4452,7 +4452,10 @@ function M.set_state(saved, pty_lookup)
         end
         state.active_tab = saved.active_tab or 1
         state.next_tab_id = saved.next_tab_id or (#state.tabs + 1)
-        state.focused_id = saved.focused_id
+        -- Left nil: the "Ensure focus is valid" block below picks a leaf
+        -- after all tabs restore. saved.focused_id may reference a PTY
+        -- that was remapped, so we can't use it verbatim here.
+        state.focused_id = nil
         state.next_split_id = saved.next_split_id or 1
 
         -- Restore floating pane settings

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1245,11 +1245,15 @@ local function serialize_node(node, cwd_lookup)
     return nil
 end
 
----Deserialize a node tree, looking up PTYs by id
+---Deserialize a node tree, looking up PTYs by id.
+---If `remap` is provided, records `saved.id -> new_id` for each pane so
+---callers can translate persisted focus references (focused_id,
+---last_focused_id) onto the remapped id space.
 ---@param saved? table
 ---@param pty_lookup fun(id: number): Pty?
+---@param remap? table<number, number>
 ---@return Node?
-local function deserialize_node(saved, pty_lookup)
+local function deserialize_node(saved, pty_lookup, remap)
     if not saved then
         return nil
     end
@@ -1258,9 +1262,13 @@ local function deserialize_node(saved, pty_lookup)
         if not pty then
             return nil
         end
+        local new_id = pty:id()
+        if remap and saved.id then
+            remap[saved.id] = new_id
+        end
         return {
             type = "pane",
-            id = pty:id(),
+            id = new_id,
             pty = pty,
             cwd = saved.cwd, -- Store cwd for spawn fallback
             ratio = saved.ratio,
@@ -1269,7 +1277,7 @@ local function deserialize_node(saved, pty_lookup)
         ---@type Node[]
         local children = {}
         for _, child in ipairs(saved.children) do
-            local restored = deserialize_node(child, pty_lookup)
+            local restored = deserialize_node(child, pty_lookup, remap)
             if restored then
                 table.insert(children, restored)
             end
@@ -1318,11 +1326,14 @@ local function serialize_floating(floating, cwd_lookup)
     }
 end
 
----Deserialize a floating pane, looking up PTY by id
+---Deserialize a floating pane, looking up PTY by id.
+---If `remap` is provided, records the floating pane's `saved.pane.id -> new_id`
+---mapping for focus translation.
 ---@param saved? table
 ---@param pty_lookup fun(id: number): Pty?
+---@param remap? table<number, number>
 ---@return FloatingPane?
-local function deserialize_floating(saved, pty_lookup)
+local function deserialize_floating(saved, pty_lookup, remap)
     if not saved or not saved.pane then
         return nil
     end
@@ -1330,10 +1341,14 @@ local function deserialize_floating(saved, pty_lookup)
     if not pty then
         return nil
     end
+    local new_id = pty:id()
+    if remap and saved.pane.id then
+        remap[saved.pane.id] = new_id
+    end
     return {
         pane = {
             type = "pane",
-            id = pty:id(),
+            id = new_id,
             pty = pty,
         },
         visible = saved.visible or false,
@@ -4405,15 +4420,23 @@ function M.set_state(saved, pty_lookup)
         return
     end
 
+    -- Build a per-restore table of old-id -> new-id mappings so persisted
+    -- focus references (focused_id, last_focused_id) can be translated onto
+    -- the remapped id space. Without this, focus would silently fall back to
+    -- the first leaf whenever the server reassigned a PTY id on restore.
+    local remap = {}
+
     -- Handle migration from old format (single root) to new format (tabs)
     if saved.tabs == nil and saved.root ~= nil then
         -- Old format: migrate to tabs
-        local restored_root = deserialize_node(saved.root, pty_lookup)
+        local restored_root = deserialize_node(saved.root, pty_lookup, remap)
         if restored_root then
             local tab_id = 1
-            -- Validate focus ID against actual pane IDs (may have been remapped)
-            local valid_focus = saved.focused_id
-            if valid_focus and not find_node_path(restored_root, valid_focus) then
+            -- Remap focused_id through the old->new table. If the saved focus
+            -- referenced a pane that couldn't be restored, fall back to the
+            -- first leaf.
+            local valid_focus = saved.focused_id and remap[saved.focused_id]
+            if not valid_focus then
                 local first = get_first_leaf(restored_root)
                 valid_focus = first and first.id or nil
             end
@@ -4433,11 +4456,12 @@ function M.set_state(saved, pty_lookup)
         -- New format: restore tabs
         state.tabs = {}
         for _, tab_data in ipairs(saved.tabs or {}) do
-            local restored_root = deserialize_node(tab_data.root, pty_lookup)
+            local restored_root = deserialize_node(tab_data.root, pty_lookup, remap)
             if restored_root then
-                -- Validate last_focused_id against actual pane IDs (may have been remapped)
-                local valid_focus = tab_data.last_focused_id
-                if valid_focus and not find_node_path(restored_root, valid_focus) then
+                -- Remap last_focused_id through the old->new table; fall back
+                -- to the first leaf of this tab if the saved focus pane is gone.
+                local valid_focus = tab_data.last_focused_id and remap[tab_data.last_focused_id]
+                if not valid_focus then
                     local first = get_first_leaf(restored_root)
                     valid_focus = first and first.id or nil
                 end
@@ -4446,16 +4470,16 @@ function M.set_state(saved, pty_lookup)
                     title = tab_data.title,
                     root = restored_root,
                     last_focused_id = valid_focus,
-                    floating = deserialize_floating(tab_data.floating, pty_lookup),
+                    floating = deserialize_floating(tab_data.floating, pty_lookup, remap),
                 })
             end
         end
         state.active_tab = saved.active_tab or 1
         state.next_tab_id = saved.next_tab_id or (#state.tabs + 1)
-        -- Left nil: the "Ensure focus is valid" block below picks a leaf
-        -- after all tabs restore. saved.focused_id may reference a PTY
-        -- that was remapped, so we can't use it verbatim here.
-        state.focused_id = nil
+        -- Remap top-level focused_id through the same table. Nil if the saved
+        -- pane is gone — the "Ensure focus is valid" block below picks a leaf
+        -- from the active tab as a safety net.
+        state.focused_id = saved.focused_id and remap[saved.focused_id] or nil
         state.next_split_id = saved.next_split_id or 1
 
         -- Restore floating pane settings

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -1260,7 +1260,7 @@ local function deserialize_node(saved, pty_lookup)
         end
         return {
             type = "pane",
-            id = saved.id,
+            id = pty:id(),
             pty = pty,
             cwd = saved.cwd, -- Store cwd for spawn fallback
             ratio = saved.ratio,
@@ -1333,7 +1333,7 @@ local function deserialize_floating(saved, pty_lookup)
     return {
         pane = {
             type = "pane",
-            id = saved.pane.id,
+            id = pty:id(),
             pty = pty,
         },
         visible = saved.visible or false,
@@ -4411,16 +4411,22 @@ function M.set_state(saved, pty_lookup)
         local restored_root = deserialize_node(saved.root, pty_lookup)
         if restored_root then
             local tab_id = 1
+            -- Validate focus ID against actual pane IDs (may have been remapped)
+            local valid_focus = saved.focused_id
+            if valid_focus and not find_node_path(restored_root, valid_focus) then
+                local first = get_first_leaf(restored_root)
+                valid_focus = first and first.id or nil
+            end
             state.tabs = {
                 {
                     id = tab_id,
                     root = restored_root,
-                    last_focused_id = saved.focused_id,
+                    last_focused_id = valid_focus,
                 },
             }
             state.active_tab = 1
             state.next_tab_id = tab_id + 1
-            state.focused_id = saved.focused_id
+            state.focused_id = valid_focus
             state.next_split_id = saved.next_split_id or 1
         end
     else
@@ -4429,11 +4435,17 @@ function M.set_state(saved, pty_lookup)
         for _, tab_data in ipairs(saved.tabs or {}) do
             local restored_root = deserialize_node(tab_data.root, pty_lookup)
             if restored_root then
+                -- Validate last_focused_id against actual pane IDs (may have been remapped)
+                local valid_focus = tab_data.last_focused_id
+                if valid_focus and not find_node_path(restored_root, valid_focus) then
+                    local first = get_first_leaf(restored_root)
+                    valid_focus = first and first.id or nil
+                end
                 table.insert(state.tabs, {
                     id = tab_data.id,
                     title = tab_data.title,
                     root = restored_root,
-                    last_focused_id = tab_data.last_focused_id,
+                    last_focused_id = valid_focus,
                     floating = deserialize_floating(tab_data.floating, pty_lookup),
                 })
             end
@@ -4458,10 +4470,10 @@ function M.set_state(saved, pty_lookup)
         end
     end
 
-    -- Ensure focus is valid
-    if #state.tabs > 0 and not state.focused_id then
+    -- Ensure focus is valid (focused_id may reference old IDs after PTY remapping)
+    if #state.tabs > 0 then
         local tab = state.tabs[state.active_tab]
-        if tab then
+        if tab and (not state.focused_id or not find_node_path(tab.root, state.focused_id)) then
             local first = get_first_leaf(tab.root)
             if first then
                 state.focused_id = first.id

--- a/src/lua/tiling_test_deserialize.lua
+++ b/src/lua/tiling_test_deserialize.lua
@@ -1,0 +1,287 @@
+--- Tests for session deserialization with PTY ID remapping
+---
+--- When a session is restored after a server restart, PTY IDs may be remapped
+--- (e.g., saved pane had id=1/pty_id=1, but server assigns pty_id=5 on restore).
+--- The deserialized pane.id must use pty:id(), not the stale saved id, otherwise
+--- pty_exited lookups fail and the client freezes.
+
+-- Minimal mock setup (self-contained, no test_helpers dependency)
+local function mock_pty(id)
+    return {
+        id = function()
+            return id
+        end,
+        title = function()
+            return "mock"
+        end,
+        cwd = function()
+            return nil
+        end,
+        size = function()
+            return { rows = 24, cols = 80, width_px = 0, height_px = 0 }
+        end,
+        send_key = function() end,
+        send_mouse = function() end,
+        send_paste = function() end,
+        set_focus = function() end,
+        close = function() end,
+        copy_selection = function() end,
+    }
+end
+
+package.loaded["prise"] = {
+    tiling = function() end,
+    Terminal = function(opts)
+        return { type = "terminal", pty = opts.pty }
+    end,
+    Text = function()
+        return { type = "text" }
+    end,
+    Column = function()
+        return { type = "column" }
+    end,
+    Row = function()
+        return { type = "row" }
+    end,
+    Stack = function()
+        return { type = "stack" }
+    end,
+    Positioned = function()
+        return { type = "positioned" }
+    end,
+    TextInput = function()
+        return { type = "text_input" }
+    end,
+    List = function()
+        return { type = "list" }
+    end,
+    Box = function()
+        return { type = "box" }
+    end,
+    Padding = function()
+        return { type = "padding" }
+    end,
+    gwidth = function(s)
+        return #s
+    end,
+    request_frame = function() end,
+    save = function() end,
+    exit = function() end,
+    get_session_name = function()
+        return "test"
+    end,
+    attach = function() end,
+    switch_session = function()
+        return true
+    end,
+    rename_session = function() end,
+    create_session = function() end,
+    create_text_input = function()
+        return {
+            text = function()
+                return ""
+            end,
+            clear = function() end,
+            insert = function() end,
+        }
+    end,
+    log = { debug = function() end, info = function() end },
+    set_timeout = function()
+        return { cancel = function() end }
+    end,
+    get_git_branch = function()
+        return nil
+    end,
+    get_time = function()
+        return "12:00"
+    end,
+    list_sessions = function()
+        return {}
+    end,
+}
+
+local tiling = require("tiling")
+
+-- Access internal state via debug.getupvalue (no get_state on main's _test)
+local function get_state()
+    for i = 1, 256 do
+        local name, val = debug.getupvalue(tiling.update, i)
+        if not name then
+            break
+        end
+        if name == "state" then
+            return val
+        end
+    end
+    error("could not find state upvalue on tiling.update")
+end
+
+-- === deserialize_node uses pty:id(), not saved.id ===
+
+-- Simulate ID remapping: saved state has pane id=1/pty_id=1,
+-- but pty_lookup returns a PTY with id=5 (server remapped it)
+local saved_single = {
+    tabs = {
+        {
+            id = 1,
+            root = { type = "pane", id = 1, pty_id = 1 },
+            last_focused_id = 1,
+        },
+    },
+    active_tab = 1,
+    next_tab_id = 2,
+    focused_id = 1,
+    next_split_id = 1,
+}
+
+local function remapping_lookup(pty_id)
+    if pty_id == 1 then
+        return mock_pty(5) -- Server assigned new ID 5
+    end
+    return nil
+end
+
+tiling.set_state(saved_single, remapping_lookup)
+local st = get_state()
+
+assert(#st.tabs == 1, "remap: tab restored")
+assert(st.tabs[1].root.id == 5, "remap: pane.id should be pty:id() (5), not saved id (1)")
+assert(st.tabs[1].root.pty:id() == 5, "remap: pty:id() is 5")
+assert(st.focused_id == 5, "remap: focused_id updated to actual PTY id")
+assert(st.tabs[1].last_focused_id == 5, "remap: last_focused_id updated to actual PTY id")
+
+-- === Split with multiple remapped panes ===
+
+local saved_split = {
+    tabs = {
+        {
+            id = 1,
+            root = {
+                type = "split",
+                split_id = 1,
+                direction = "row",
+                children = {
+                    { type = "pane", id = 10, pty_id = 10 },
+                    { type = "pane", id = 20, pty_id = 20 },
+                },
+            },
+            last_focused_id = 20,
+        },
+    },
+    active_tab = 1,
+    next_tab_id = 2,
+    focused_id = 20,
+    next_split_id = 2,
+}
+
+local function split_remap_lookup(pty_id)
+    if pty_id == 10 then
+        return mock_pty(100)
+    elseif pty_id == 20 then
+        return mock_pty(200)
+    end
+    return nil
+end
+
+tiling.set_state(saved_split, split_remap_lookup)
+st = get_state()
+
+assert(#st.tabs == 1, "split remap: tab restored")
+local root = st.tabs[1].root
+assert(root.type == "split", "split remap: root is split")
+assert(root.children[1].id == 100, "split remap: first pane id is 100")
+assert(root.children[2].id == 200, "split remap: second pane id is 200")
+assert(st.focused_id == 100 or st.focused_id == 200, "split remap: focused_id is a valid remapped id")
+assert(
+    st.tabs[1].last_focused_id == 100 or st.tabs[1].last_focused_id == 200,
+    "split remap: last_focused_id is a valid remapped id"
+)
+
+-- === Floating pane with remapped ID ===
+
+local saved_floating = {
+    tabs = {
+        {
+            id = 1,
+            root = { type = "pane", id = 1, pty_id = 1 },
+            last_focused_id = 1,
+            floating = {
+                pane = { type = "pane", id = 2, pty_id = 2 },
+                visible = true,
+            },
+        },
+    },
+    active_tab = 1,
+    next_tab_id = 2,
+    focused_id = 1,
+    next_split_id = 1,
+}
+
+local function floating_remap_lookup(pty_id)
+    if pty_id == 1 then
+        return mock_pty(50)
+    elseif pty_id == 2 then
+        return mock_pty(60)
+    end
+    return nil
+end
+
+tiling.set_state(saved_floating, floating_remap_lookup)
+st = get_state()
+
+assert(st.tabs[1].root.id == 50, "floating remap: root pane id is 50")
+assert(st.tabs[1].floating.pane.id == 60, "floating remap: floating pane id is 60")
+assert(st.tabs[1].floating.visible == true, "floating remap: visibility preserved")
+
+-- === Old format migration with remapped ID ===
+
+local saved_old_format = {
+    root = { type = "pane", id = 3, pty_id = 3 },
+    focused_id = 3,
+    next_split_id = 1,
+}
+
+local function old_format_remap(pty_id)
+    if pty_id == 3 then
+        return mock_pty(30)
+    end
+    return nil
+end
+
+tiling.set_state(saved_old_format, old_format_remap)
+st = get_state()
+
+assert(#st.tabs == 1, "old format remap: tab created")
+assert(st.tabs[1].root.id == 30, "old format remap: pane id is 30")
+assert(st.focused_id == 30, "old format remap: focused_id updated")
+assert(st.tabs[1].last_focused_id == 30, "old format remap: last_focused_id updated")
+
+-- === No remapping: IDs unchanged when PTY ID matches saved ID ===
+
+local saved_no_remap = {
+    tabs = {
+        {
+            id = 1,
+            root = { type = "pane", id = 7, pty_id = 7 },
+            last_focused_id = 7,
+        },
+    },
+    active_tab = 1,
+    next_tab_id = 2,
+    focused_id = 7,
+    next_split_id = 1,
+}
+
+local function identity_lookup(pty_id)
+    if pty_id == 7 then
+        return mock_pty(7) -- Same ID, no remapping
+    end
+    return nil
+end
+
+tiling.set_state(saved_no_remap, identity_lookup)
+st = get_state()
+
+assert(st.tabs[1].root.id == 7, "no remap: pane id stays 7")
+assert(st.focused_id == 7, "no remap: focused_id stays 7")
+assert(st.tabs[1].last_focused_id == 7, "no remap: last_focused_id stays 7")

--- a/src/lua/tiling_test_deserialize.lua
+++ b/src/lua/tiling_test_deserialize.lua
@@ -102,19 +102,7 @@ package.loaded["prise"] = {
 
 local tiling = require("tiling")
 
--- Access internal state via debug.getupvalue (no get_state on main's _test)
-local function get_state()
-    for i = 1, 256 do
-        local name, val = debug.getupvalue(tiling.update, i)
-        if not name then
-            break
-        end
-        if name == "state" then
-            return val
-        end
-    end
-    error("could not find state upvalue on tiling.update")
-end
+local get_state = tiling._test.get_state
 
 -- === deserialize_node uses pty:id(), not saved.id ===
 

--- a/src/lua/tiling_test_deserialize.lua
+++ b/src/lua/tiling_test_deserialize.lua
@@ -139,6 +139,9 @@ assert(st.focused_id == 5, "remap: focused_id updated to actual PTY id")
 assert(st.tabs[1].last_focused_id == 5, "remap: last_focused_id updated to actual PTY id")
 
 -- === Split with multiple remapped panes ===
+-- Saved focus was on pty_id=20 which the server remaps to id=200.
+-- set_state must translate saved.focused_id (=20) through the old->new
+-- remap table and land on 200 — not fall back to the first leaf (100).
 
 local saved_split = {
     tabs = {
@@ -179,11 +182,8 @@ local root = st.tabs[1].root
 assert(root.type == "split", "split remap: root is split")
 assert(root.children[1].id == 100, "split remap: first pane id is 100")
 assert(root.children[2].id == 200, "split remap: second pane id is 200")
-assert(st.focused_id == 100 or st.focused_id == 200, "split remap: focused_id is a valid remapped id")
-assert(
-    st.tabs[1].last_focused_id == 100 or st.tabs[1].last_focused_id == 200,
-    "split remap: last_focused_id is a valid remapped id"
-)
+assert(st.focused_id == 200, "split remap: focused_id follows remapped pane to 200")
+assert(st.tabs[1].last_focused_id == 200, "split remap: last_focused_id follows remapped pane to 200")
 
 -- === Floating pane with remapped ID ===
 

--- a/src/lua_test.zig
+++ b/src/lua_test.zig
@@ -49,3 +49,9 @@ test "lua tiling zoom state" {
     defer lua.deinit();
     try runLuaTest(lua, "src/lua/tiling_test_zoom_state.lua");
 }
+
+test "lua tiling deserialize" {
+    var lua = try setupLua(std.testing.allocator);
+    defer lua.deinit();
+    try runLuaTest(lua, "src/lua/tiling_test_deserialize.lua");
+}


### PR DESCRIPTION
When sessions are restored after server restart, PTY IDs may be remapped
by the server. `deserialize_node` and `deserialize_floating` store
`saved.id` instead of `pty:id()`, so pane IDs diverge from actual PTY IDs.
Panes become unresponsive — `pty_exited` lookups fail because the tiling
layout references stale IDs.

Fix: use `pty:id()` (the live remapped ID) instead of `saved.id` in both
deserialization paths. Validate focus IDs against the actual pane tree
after restore and fall back to the first leaf when the saved focus ID no
longer exists. A safety net in client.zig force-quits when all surfaces
exit but Lua hasn't triggered exit.

5 test scenarios cover identity mapping, single pane remap, split with
multiple remapped panes, floating pane remap, and old-format migration.