### PR TITLE
add test filter build option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,6 +126,10 @@ pub fn build(b: *std.Build) void {
 
     const tests = b.addTest(.{
         .root_module = exe_mod,
+        .filters = if (b.option([]const u8, "test-filter", "Run only tests matching this string")) |f|
+            &.{f}
+        else
+            &.{},
     });
 
     const test_cmd = b.addRunArtifact(tests);


### PR DESCRIPTION
Add `-Dtest-filter="pattern"` build option to run a subset of tests
during development.

```
zig build test -Dtest-filter="spawn"
```

Passes the filter to `addTest`'s `.filters` field. No filter runs all
tests (existing behavior). 4 lines in build.zig.