### PR TITLE
swap dialog text input to vaxis gap-buffer engine

### DIFF
--- a/src/TextInput.zig
+++ b/src/TextInput.zig
@@ -124,6 +124,21 @@ pub fn render(self: *TextInput, win: vaxis.Window, style: vaxis.Style) void {
         self.scroll_offset = cursor_display_col - win.width + 1;
     }
 
+    // Snap scroll_offset down to a grapheme boundary in first_half so we
+    // never render a partial wide grapheme as the leftmost visible cell.
+    // Walk graphemes tracking their start display columns; the final `cum`
+    // is the largest boundary ≤ the desired scroll_offset.
+    if (self.scroll_offset > 0) {
+        var snap_iter = unicode.graphemeIterator(first_half);
+        var cum: u16 = 0;
+        while (snap_iter.next()) |grapheme| {
+            const w = win.gwidth(grapheme.bytes(first_half));
+            if (cum + w > self.scroll_offset) break;
+            cum += w;
+        }
+        self.scroll_offset = cum;
+    }
+
     var col: u16 = 0;
     var abs_col: u16 = 0;
 
@@ -162,6 +177,16 @@ pub fn render(self: *TextInput, win: vaxis.Window, style: vaxis.Style) void {
                     .style = cursor_style,
                 });
                 col += w;
+            } else if (col < win.width) {
+                // Cursor grapheme is wider than the remaining columns.
+                // Fall back to a 1-wide reverse-space marker so the
+                // cursor position is still visible instead of silently
+                // dropping the cursor cell entirely.
+                win.writeCell(col, 0, .{
+                    .char = .{ .grapheme = " ", .width = 1 },
+                    .style = cursor_style,
+                });
+                col += 1;
             }
 
             // Render rest of second half (normal style)

--- a/src/TextInput.zig
+++ b/src/TextInput.zig
@@ -26,9 +26,7 @@ pub fn deinit(self: *TextInput) void {
     self.vaxis_input.deinit();
 }
 
-// -----------------------------------------------------------------------
 // Editing — delegate to vaxis
-// -----------------------------------------------------------------------
 
 pub fn insertSlice(self: *TextInput, str: []const u8) !void {
     try self.vaxis_input.insertSliceAtCursor(str);
@@ -71,9 +69,7 @@ pub fn clear(self: *TextInput) void {
     self.scroll_offset = 0;
 }
 
-// -----------------------------------------------------------------------
 // New editing methods — expose additional vaxis capabilities
-// -----------------------------------------------------------------------
 
 pub fn deleteToStart(self: *TextInput) void {
     self.vaxis_input.deleteToStart();
@@ -91,9 +87,7 @@ pub fn moveWordForward(self: *TextInput) void {
     self.vaxis_input.moveForwardWordwise();
 }
 
-// -----------------------------------------------------------------------
 // Text access
-// -----------------------------------------------------------------------
 
 /// Return the full text as a contiguous slice. Caller must free with
 /// the same allocator that was passed to `init`.
@@ -106,9 +100,7 @@ pub fn text(self: *const TextInput) ![]const u8 {
     return buf;
 }
 
-// -----------------------------------------------------------------------
 // Rendering — prise's own style (reverse-video block cursor, bg fill)
-// -----------------------------------------------------------------------
 
 pub fn render(self: *TextInput, win: vaxis.Window, style: vaxis.Style) void {
     if (win.width == 0) return;
@@ -204,9 +196,7 @@ pub fn render(self: *TextInput, win: vaxis.Window, style: vaxis.Style) void {
     }
 }
 
-// ===========================================================================
 // Tests
-// ===========================================================================
 
 const tui_test = @import("tui_test.zig");
 
@@ -294,9 +284,7 @@ test "scroll offset via render" {
     try std.testing.expect(input.scroll_offset > 0);
 }
 
-// -----------------------------------------------------------------------
 // New editing method tests
-// -----------------------------------------------------------------------
 
 test "killLine deletes from cursor to end" {
     const allocator = std.testing.allocator;
@@ -433,9 +421,7 @@ test "grapheme-aware cursor movement" {
     }
 }
 
-// ===========================================================================
 // Rendering Tests
-// ===========================================================================
 
 test "render - basic text with cursor at end" {
     const allocator = std.testing.allocator;

--- a/src/TextInput.zig
+++ b/src/TextInput.zig
@@ -1,146 +1,214 @@
-//! Text input widget with cursor and editing support.
+//! Text input widget backed by vaxis gap-buffer TextInput.
+//!
+//! Delegates editing to `vaxis.widgets.TextInput` for grapheme-aware
+//! cursor movement and readline primitives. Keeps prise's own render
+//! logic (reverse-video block cursor, background fill, no ellipsis).
 
 const std = @import("std");
 
 const vaxis = @import("vaxis");
+const unicode = vaxis.unicode;
 
 const TextInput = @This();
 
 allocator: std.mem.Allocator,
-buffer: std.ArrayList(u8),
-cursor: usize = 0,
-scroll_offset: usize = 0,
+vaxis_input: vaxis.widgets.TextInput,
+scroll_offset: u16 = 0,
 
 pub fn init(allocator: std.mem.Allocator) TextInput {
     return .{
         .allocator = allocator,
-        .buffer = std.ArrayList(u8).empty,
+        .vaxis_input = vaxis.widgets.TextInput.init(allocator),
     };
 }
 
 pub fn deinit(self: *TextInput) void {
-    self.buffer.deinit(self.allocator);
+    self.vaxis_input.deinit();
 }
 
-pub fn insert(self: *TextInput, char: u8) !void {
-    try self.buffer.insert(self.allocator, self.cursor, char);
-    self.cursor += 1;
-}
+// -----------------------------------------------------------------------
+// Editing — delegate to vaxis
+// -----------------------------------------------------------------------
 
-pub fn insertSlice(self: *TextInput, slice: []const u8) !void {
-    try self.buffer.insertSlice(self.allocator, self.cursor, slice);
-    self.cursor += slice.len;
+pub fn insertSlice(self: *TextInput, str: []const u8) !void {
+    try self.vaxis_input.insertSliceAtCursor(str);
 }
 
 pub fn deleteBackward(self: *TextInput) void {
-    if (self.cursor > 0) {
-        _ = self.buffer.orderedRemove(self.cursor - 1);
-        self.cursor -= 1;
-    }
+    self.vaxis_input.deleteBeforeCursor();
 }
 
 pub fn deleteForward(self: *TextInput) void {
-    if (self.cursor < self.buffer.items.len) {
-        _ = self.buffer.orderedRemove(self.cursor);
-    }
+    self.vaxis_input.deleteAfterCursor();
 }
 
 pub fn deleteWordBackward(self: *TextInput) void {
-    if (self.cursor == 0) return;
-
-    var end = self.cursor;
-    while (end > 0 and self.buffer.items[end - 1] == ' ') {
-        end -= 1;
-    }
-    while (end > 0 and self.buffer.items[end - 1] != ' ') {
-        end -= 1;
-    }
-
-    const count = self.cursor - end;
-    for (0..count) |_| {
-        _ = self.buffer.orderedRemove(end);
-    }
-    self.cursor = end;
+    self.vaxis_input.deleteWordBefore();
 }
 
 pub fn killLine(self: *TextInput) void {
-    self.buffer.shrinkRetainingCapacity(self.cursor);
+    self.vaxis_input.deleteToEnd();
 }
 
 pub fn moveLeft(self: *TextInput) void {
-    if (self.cursor > 0) {
-        self.cursor -= 1;
-    }
+    self.vaxis_input.cursorLeft();
 }
 
 pub fn moveRight(self: *TextInput) void {
-    if (self.cursor < self.buffer.items.len) {
-        self.cursor += 1;
-    }
+    self.vaxis_input.cursorRight();
 }
 
 pub fn moveToStart(self: *TextInput) void {
-    self.cursor = 0;
+    self.vaxis_input.buf.moveGapLeft(self.vaxis_input.buf.firstHalf().len);
 }
 
 pub fn moveToEnd(self: *TextInput) void {
-    self.cursor = self.buffer.items.len;
+    self.vaxis_input.buf.moveGapRight(self.vaxis_input.buf.secondHalf().len);
 }
 
 pub fn clear(self: *TextInput) void {
-    self.buffer.clearRetainingCapacity();
-    self.cursor = 0;
+    self.vaxis_input.clearRetainingCapacity();
     self.scroll_offset = 0;
 }
 
-pub fn text(self: *const TextInput) []const u8 {
-    return self.buffer.items;
+// -----------------------------------------------------------------------
+// New editing methods — expose additional vaxis capabilities
+// -----------------------------------------------------------------------
+
+pub fn deleteToStart(self: *TextInput) void {
+    self.vaxis_input.deleteToStart();
 }
 
-pub fn updateScrollOffset(self: *TextInput, visible_width: u16) void {
-    if (visible_width == 0) return;
-
-    const width: usize = visible_width;
-
-    if (self.cursor < self.scroll_offset) {
-        self.scroll_offset = self.cursor;
-    } else if (self.cursor >= self.scroll_offset + width) {
-        self.scroll_offset = self.cursor - width + 1;
-    }
+pub fn deleteWordAfter(self: *TextInput) void {
+    self.vaxis_input.deleteWordAfter();
 }
 
-pub fn visibleText(self: *const TextInput, visible_width: u16) []const u8 {
-    const items = self.buffer.items;
-    if (items.len == 0) return "";
-
-    const start = @min(self.scroll_offset, items.len);
-    const end = @min(start + visible_width, items.len);
-    return items[start..end];
+pub fn moveWordBackward(self: *TextInput) void {
+    self.vaxis_input.moveBackwardWordwise();
 }
 
-pub fn visibleCursorPos(self: *const TextInput) usize {
-    return self.cursor - self.scroll_offset;
+pub fn moveWordForward(self: *TextInput) void {
+    self.vaxis_input.moveForwardWordwise();
 }
 
-pub fn render(self: *const TextInput, win: vaxis.Window, style: vaxis.Style) void {
-    const visible = self.visibleText(@intCast(win.width));
-    const cursor_x = self.visibleCursorPos();
+// -----------------------------------------------------------------------
+// Text access
+// -----------------------------------------------------------------------
 
-    // Fill the entire line with background first
-    for (0..win.width) |col| {
-        const is_cursor = col == cursor_x;
-        var cell_style = style;
-        if (is_cursor) {
-            cell_style.reverse = true;
+/// Return the full text as a contiguous slice. Caller must free with
+/// the same allocator that was passed to `init`.
+pub fn text(self: *const TextInput) ![]const u8 {
+    const first = self.vaxis_input.buf.firstHalf();
+    const second = self.vaxis_input.buf.secondHalf();
+    const buf = try self.allocator.alloc(u8, first.len + second.len);
+    @memcpy(buf[0..first.len], first);
+    @memcpy(buf[first.len..], second);
+    return buf;
+}
+
+// -----------------------------------------------------------------------
+// Rendering — prise's own style (reverse-video block cursor, bg fill)
+// -----------------------------------------------------------------------
+
+pub fn render(self: *TextInput, win: vaxis.Window, style: vaxis.Style) void {
+    if (win.width == 0) return;
+
+    const first_half = self.vaxis_input.buf.firstHalf();
+    const second_half = self.vaxis_input.buf.secondHalf();
+
+    // Calculate cursor display column for scroll adjustment
+    var cursor_display_col: u16 = 0;
+    {
+        var iter = unicode.graphemeIterator(first_half);
+        while (iter.next()) |grapheme| {
+            cursor_display_col += win.gwidth(grapheme.bytes(first_half));
         }
+    }
 
-        const grapheme: []const u8 = if (col < visible.len) visible[col .. col + 1] else " ";
-        win.writeCell(@intCast(col), 0, .{
-            .char = .{ .grapheme = grapheme, .width = 1 },
-            .style = cell_style,
+    // Adjust scroll offset to keep cursor visible
+    if (cursor_display_col < self.scroll_offset) {
+        self.scroll_offset = cursor_display_col;
+    } else if (cursor_display_col >= self.scroll_offset + win.width) {
+        self.scroll_offset = cursor_display_col - win.width + 1;
+    }
+
+    var col: u16 = 0;
+    var abs_col: u16 = 0;
+
+    // Render first half (before cursor)
+    {
+        var iter = unicode.graphemeIterator(first_half);
+        while (iter.next()) |grapheme| {
+            const g = grapheme.bytes(first_half);
+            const w = win.gwidth(g);
+            if (abs_col + w <= self.scroll_offset) {
+                abs_col += w;
+                continue;
+            }
+            if (col + w > win.width) break;
+            win.writeCell(col, 0, .{
+                .char = .{ .grapheme = g, .width = @intCast(w) },
+                .style = style,
+            });
+            col += w;
+            abs_col += w;
+        }
+    }
+
+    // Render cursor cell: first grapheme of second half with reverse,
+    // or a reversed space if the cursor is at the end of input.
+    var cursor_style = style;
+    cursor_style.reverse = true;
+    {
+        var iter = unicode.graphemeIterator(second_half);
+        if (iter.next()) |grapheme| {
+            const g = grapheme.bytes(second_half);
+            const w = win.gwidth(g);
+            if (col + w <= win.width) {
+                win.writeCell(col, 0, .{
+                    .char = .{ .grapheme = g, .width = @intCast(w) },
+                    .style = cursor_style,
+                });
+                col += w;
+            }
+
+            // Render rest of second half (normal style)
+            while (iter.next()) |g2| {
+                const g2_bytes = g2.bytes(second_half);
+                const w2 = win.gwidth(g2_bytes);
+                if (col + w2 > win.width) break;
+                win.writeCell(col, 0, .{
+                    .char = .{ .grapheme = g2_bytes, .width = @intCast(w2) },
+                    .style = style,
+                });
+                col += w2;
+            }
+        } else {
+            // Cursor at end of input — show reversed space
+            if (col < win.width) {
+                win.writeCell(col, 0, .{
+                    .char = .{ .grapheme = " ", .width = 1 },
+                    .style = cursor_style,
+                });
+                col += 1;
+            }
+        }
+    }
+
+    // Fill remaining width with background
+    while (col < win.width) : (col += 1) {
+        win.writeCell(col, 0, .{
+            .char = .{ .grapheme = " ", .width = 1 },
+            .style = style,
         });
     }
 }
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const tui_test = @import("tui_test.zig");
 
 test "basic insert and cursor movement" {
     const allocator = std.testing.allocator;
@@ -148,18 +216,18 @@ test "basic insert and cursor movement" {
     var input = TextInput.init(allocator);
     defer input.deinit();
 
-    try input.insert('a');
-    try input.insert('b');
-    try input.insert('c');
+    try input.insertSlice("abc");
 
-    try std.testing.expectEqualStrings("abc", input.text());
-    try std.testing.expectEqual(@as(usize, 3), input.cursor);
+    const t1 = try input.text();
+    defer allocator.free(t1);
+    try std.testing.expectEqualStrings("abc", t1);
 
     input.moveLeft();
-    try std.testing.expectEqual(@as(usize, 2), input.cursor);
 
-    try input.insert('X');
-    try std.testing.expectEqualStrings("abXc", input.text());
+    try input.insertSlice("X");
+    const t2 = try input.text();
+    defer allocator.free(t2);
+    try std.testing.expectEqualStrings("abXc", t2);
 }
 
 test "delete backward and forward" {
@@ -169,48 +237,171 @@ test "delete backward and forward" {
     defer input.deinit();
 
     try input.insertSlice("hello");
-    try std.testing.expectEqualStrings("hello", input.text());
+
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("hello", t);
+    }
 
     input.deleteBackward();
-    try std.testing.expectEqualStrings("hell", input.text());
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("hell", t);
+    }
 
     input.moveToStart();
     input.deleteForward();
-    try std.testing.expectEqualStrings("ell", input.text());
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("ell", t);
+    }
 }
 
-test "scroll offset" {
+test "delete word backward" {
     const allocator = std.testing.allocator;
 
     var input = TextInput.init(allocator);
     defer input.deinit();
 
-    try input.insertSlice("hello world this is a long string");
+    try input.insertSlice("hello world");
 
-    input.updateScrollOffset(10);
+    input.deleteWordBackward();
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("hello ", t);
+    }
+}
+
+test "scroll offset via render" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    try input.insertSlice("abcdefghijklmnop");
+
+    // Rendering into a narrow window triggers scroll adjustment
+    var screen = try tui_test.createScreen(allocator, 5, 1);
+    defer screen.deinit(allocator);
+
+    const win = tui_test.windowFromScreen(&screen);
+    input.render(win, .{});
 
     try std.testing.expect(input.scroll_offset > 0);
-    try std.testing.expect(input.visibleText(10).len <= 10);
 }
 
-test "visible cursor position" {
+// -----------------------------------------------------------------------
+// New editing method tests
+// -----------------------------------------------------------------------
+
+test "delete to start" {
     const allocator = std.testing.allocator;
 
     var input = TextInput.init(allocator);
     defer input.deinit();
 
-    try input.insertSlice("abcdefghij");
-    input.cursor = 5;
-    input.scroll_offset = 3;
+    try input.insertSlice("hello world");
+    // Move cursor to middle (after "hello")
+    for (0..6) |_| input.moveLeft();
 
-    try std.testing.expectEqual(@as(usize, 2), input.visibleCursorPos());
+    input.deleteToStart();
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings(" world", t);
+    }
 }
 
-// ============================================================================
-// Rendering Tests
-// ============================================================================
+test "delete word after" {
+    const allocator = std.testing.allocator;
 
-const tui_test = @import("tui_test.zig");
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    try input.insertSlice("hello world");
+    input.moveToStart();
+
+    input.deleteWordAfter();
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings(" world", t);
+    }
+}
+
+test "move word backward and forward" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    try input.insertSlice("one two three");
+    // Cursor at end
+
+    input.moveWordBackward();
+    // Cursor should be before "three"
+    try input.insertSlice("X");
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("one two Xthree", t);
+    }
+
+    // Move back to undo the X insertion effect, then test forward
+    input.deleteBackward(); // remove X
+    input.moveToStart();
+    input.moveWordForward();
+    // Cursor should be after "one"
+    try input.insertSlice("Y");
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("oneY two three", t);
+    }
+}
+
+test "grapheme-aware cursor movement" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    // Insert multi-byte characters: "café"
+    try input.insertSlice("caf\xc3\xa9");
+
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("caf\xc3\xa9", t);
+    }
+
+    // moveLeft should move over the whole 'é' grapheme, not just one byte
+    input.moveLeft();
+    try input.insertSlice("X");
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("cafX\xc3\xa9", t);
+    }
+
+    // deleteBackward should remove the whole 'X'
+    input.deleteBackward();
+    // deleteForward should remove the whole 'é'
+    input.deleteForward();
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("caf", t);
+    }
+}
+
+// ===========================================================================
+// Rendering Tests
+// ===========================================================================
 
 test "render - basic text with cursor at end" {
     const allocator = std.testing.allocator;
@@ -273,7 +464,6 @@ test "render - with scrolling" {
     defer input.deinit();
 
     try input.insertSlice("abcdefghijklmnop");
-    input.updateScrollOffset(5);
 
     var screen = try tui_test.createScreen(allocator, 5, 1);
     defer screen.deinit(allocator);
@@ -281,12 +471,12 @@ test "render - with scrolling" {
     const win = tui_test.windowFromScreen(&screen);
     input.render(win, .{});
 
-    const ascii = try tui_test.screenToAscii(allocator, &screen, 5, 1);
-    defer allocator.free(ascii);
+    // With 16 chars and cursor at end in a 5-wide window, scroll kicks in
+    try std.testing.expect(input.scroll_offset > 0);
 
-    // With scroll, we should see the end portion
-    const visible = input.visibleText(5);
-    try std.testing.expect(visible.len <= 5);
+    // Cursor (reversed space at end) should be at the last visible position
+    const cursor_cell = screen.readCell(4, 0).?;
+    try std.testing.expect(cursor_cell.style.reverse);
 }
 
 test "render - empty input shows cursor" {

--- a/src/TextInput.zig
+++ b/src/TextInput.zig
@@ -298,6 +298,40 @@ test "scroll offset via render" {
 // New editing method tests
 // -----------------------------------------------------------------------
 
+test "killLine deletes from cursor to end" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    try input.insertSlice("hello world");
+    // Move cursor to after "hello" (back over " world" = 6 graphemes)
+    for (0..6) |_| input.moveLeft();
+
+    input.killLine();
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("hello", t);
+    }
+}
+
+test "killLine at end of input is a no-op" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    try input.insertSlice("hello world");
+    // Cursor already at end — killLine should leave text unchanged
+    input.killLine();
+    {
+        const t = try input.text();
+        defer allocator.free(t);
+        try std.testing.expectEqualStrings("hello world", t);
+    }
+}
+
 test "delete to start" {
     const allocator = std.testing.allocator;
 

--- a/src/TextInput.zig
+++ b/src/TextInput.zig
@@ -513,6 +513,70 @@ test "render - with scrolling" {
     try std.testing.expect(cursor_cell.style.reverse);
 }
 
+test "render - wide characters with scrolling" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    // 4 CJK chars (8 display cols) + 4 ASCII (4 display cols) = 12 total
+    try input.insertSlice("你好世界abcd");
+
+    // Use width 7 so the scroll boundary (offset 6) aligns with a
+    // wide-char edge, giving a clean layout for assertions.
+    var screen = try tui_test.createScreen(allocator, 7, 1);
+    defer screen.deinit(allocator);
+
+    const win = tui_test.windowFromScreen(&screen);
+    input.render(win, .{});
+
+    // Cursor at display col 12 in a 7-wide window — scroll must kick in
+    try std.testing.expect(input.scroll_offset > 0);
+
+    // Cursor (reversed space at end-of-input) at last visible column
+    const cursor_cell = screen.readCell(6, 0).?;
+    try std.testing.expect(cursor_cell.style.reverse);
+
+    // Verify no wide character is split: CJK cells must have width 2
+    for (0..7) |col| {
+        const cell = screen.readCell(@intCast(col), 0).?;
+        if (cell.char.grapheme.len >= 3) {
+            try std.testing.expectEqual(@as(u8, 2), cell.char.width);
+        }
+    }
+
+    // Move cursor left into the CJK region and re-render.
+    // 5 left moves: d, c, b, a, 界 — cursor lands on 界
+    for (0..5) |_| input.moveLeft();
+
+    var screen2 = try tui_test.createScreen(allocator, 7, 1);
+    defer screen2.deinit(allocator);
+
+    const win2 = tui_test.windowFromScreen(&screen2);
+    input.render(win2, .{});
+
+    // Find the cursor cell and verify it covers a wide character
+    var found_cursor = false;
+    for (0..7) |col| {
+        const cell = screen2.readCell(@intCast(col), 0).?;
+        if (cell.style.reverse) {
+            found_cursor = true;
+            // Cursor is on 界 — must be full-width
+            try std.testing.expectEqual(@as(u8, 2), cell.char.width);
+            break;
+        }
+    }
+    try std.testing.expect(found_cursor);
+
+    // Verify no wide char is split in the re-rendered screen
+    for (0..7) |col| {
+        const cell = screen2.readCell(@intCast(col), 0).?;
+        if (cell.char.grapheme.len >= 3) {
+            try std.testing.expectEqual(@as(u8, 2), cell.char.width);
+        }
+    }
+}
+
 test "render - empty input shows cursor" {
     const allocator = std.testing.allocator;
 

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -2920,13 +2920,6 @@ function M.update(event)
                 end
                 prise.request_frame()
                 return
-            elseif k == "Backspace" then
-                state.session_picker.input:delete_backward()
-                local new_filtered = filter_sessions(state.session_picker.input:text())
-                state.session_picker.selected = math.min(state.session_picker.selected, math.max(1, #new_filtered))
-                state.session_picker.scroll_offset = 0
-                prise.request_frame()
-                return
             elseif k == "D" and event.data.shift then
                 -- Delete the selected session (Shift+D)
                 if #filtered > 0 then
@@ -2954,15 +2947,24 @@ function M.update(event)
                 -- Rename the selected session (Shift+R)
                 open_session_rename()
                 return
-            elseif #k == 1 and not event.data.ctrl and not event.data.alt and not event.data.super then
-                state.session_picker.input:insert(k)
-                local new_filtered = filter_sessions(state.session_picker.input:text())
-                state.session_picker.selected = math.min(state.session_picker.selected, math.max(1, #new_filtered))
-                state.session_picker.scroll_offset = 0
-                prise.request_frame()
+            else
+                -- Route remaining editing keys (char insert, backspace,
+                -- cursor movement, word motions, kill_line, etc.) through
+                -- the shared handler so the picker's search field behaves
+                -- like other dialog text inputs. List navigation and
+                -- action keys are already handled above.
+                local old_text = state.session_picker.input:text()
+                if handle_text_input_key(state.session_picker.input, event.data) then
+                    local new_text = state.session_picker.input:text()
+                    if new_text ~= old_text then
+                        local new_filtered = filter_sessions(new_text)
+                        state.session_picker.selected =
+                            math.min(state.session_picker.selected, math.max(1, #new_filtered))
+                        state.session_picker.scroll_offset = 0
+                    end
+                end
                 return
             end
-            return
         end
 
         -- Handle layout picker

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -546,6 +546,42 @@ local function handle_text_input_key(input, key_data)
         input:move_to_end()
         prise.request_frame()
         return true
+    elseif k == "u" and ctrl then
+        input:delete_to_start()
+        prise.request_frame()
+        return true
+    elseif k == "d" and ctrl then
+        input:delete_forward()
+        prise.request_frame()
+        return true
+    elseif k == "h" and ctrl then
+        input:delete_backward()
+        prise.request_frame()
+        return true
+    elseif k == "b" and ctrl then
+        input:move_left()
+        prise.request_frame()
+        return true
+    elseif k == "f" and ctrl then
+        input:move_right()
+        prise.request_frame()
+        return true
+    elseif k == "b" and key_data.alt then
+        input:move_word_backward()
+        prise.request_frame()
+        return true
+    elseif k == "f" and key_data.alt then
+        input:move_word_forward()
+        prise.request_frame()
+        return true
+    elseif k == "d" and key_data.alt then
+        input:delete_word_after()
+        prise.request_frame()
+        return true
+    elseif k == "Backspace" and key_data.alt then
+        input:delete_word_backward()
+        prise.request_frame()
+        return true
     elseif #k == 1 and not ctrl and not key_data.alt and not key_data.super then
         input:insert(k)
         prise.request_frame()

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -530,6 +530,14 @@ local function handle_text_input_key(input, key_data)
         input:kill_line()
         prise.request_frame()
         return true
+    elseif k == "ArrowLeft" and key_data.alt then
+        input:move_word_backward()
+        prise.request_frame()
+        return true
+    elseif k == "ArrowRight" and key_data.alt then
+        input:move_word_forward()
+        prise.request_frame()
+        return true
     elseif k == "ArrowLeft" then
         input:move_left()
         prise.request_frame()

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -514,7 +514,7 @@ local function handle_text_input_key(input, key_data)
     local k = key_data.key
     local ctrl = key_data.ctrl
 
-    if k == "Backspace" then
+    if k == "Backspace" and not key_data.alt then
         input:delete_backward()
         prise.request_frame()
         return true

--- a/src/lua/types/text_input.lua
+++ b/src/lua/types/text_input.lua
@@ -43,5 +43,17 @@ function TextInput:move_to_end() end
 ---Clear all text and reset cursor
 function TextInput:clear() end
 
+---Delete from cursor to start of line
+function TextInput:delete_to_start() end
+
+---Delete word after cursor
+function TextInput:delete_word_after() end
+
+---Move cursor backward one word
+function TextInput:move_word_backward() end
+
+---Move cursor forward one word
+function TextInput:move_word_forward() end
+
 ---Destroy the TextInput and free resources
 function TextInput:destroy() end

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -1412,6 +1412,22 @@ fn textInputIndex(lua: *ziglua.Lua) i32 {
         lua.pushFunction(ziglua.wrap(textInputDestroy));
         return 1;
     }
+    if (std.mem.eql(u8, key, "delete_to_start")) {
+        lua.pushFunction(ziglua.wrap(textInputDeleteToStart));
+        return 1;
+    }
+    if (std.mem.eql(u8, key, "delete_word_after")) {
+        lua.pushFunction(ziglua.wrap(textInputDeleteWordAfter));
+        return 1;
+    }
+    if (std.mem.eql(u8, key, "move_word_backward")) {
+        lua.pushFunction(ziglua.wrap(textInputMoveWordBackward));
+        return 1;
+    }
+    if (std.mem.eql(u8, key, "move_word_forward")) {
+        lua.pushFunction(ziglua.wrap(textInputMoveWordForward));
+        return 1;
+    }
     return 0;
 }
 
@@ -1431,7 +1447,9 @@ fn textInputText(lua: *ziglua.Lua) i32 {
         lua.pushNil();
         return 1;
     };
-    _ = lua.pushString(input.text());
+    const t = input.text() catch return 0;
+    defer input.allocator.free(t);
+    _ = lua.pushString(t);
     return 1;
 }
 
@@ -1506,6 +1524,30 @@ fn textInputDestroy(lua: *ziglua.Lua) i32 {
         entry.value.deinit();
         ui.allocator.destroy(entry.value);
     }
+    return 0;
+}
+
+fn textInputDeleteToStart(lua: *ziglua.Lua) i32 {
+    const input = getTextInput(lua) orelse return 0;
+    input.deleteToStart();
+    return 0;
+}
+
+fn textInputDeleteWordAfter(lua: *ziglua.Lua) i32 {
+    const input = getTextInput(lua) orelse return 0;
+    input.deleteWordAfter();
+    return 0;
+}
+
+fn textInputMoveWordBackward(lua: *ziglua.Lua) i32 {
+    const input = getTextInput(lua) orelse return 0;
+    input.moveWordBackward();
+    return 0;
+}
+
+fn textInputMoveWordForward(lua: *ziglua.Lua) i32 {
+    const input = getTextInput(lua) orelse return 0;
+    input.moveWordForward();
     return 0;
 }
 

--- a/src/widget.zig
+++ b/src/widget.zig
@@ -4525,9 +4525,277 @@ test "render Positioned - anchor bottom_right" {
     const ascii = try tui_test.screenToAscii(allocator, &screen, 5, 3);
     defer allocator.free(ascii);
 
+    try tui_test.expectAsciiEqual("     \n     \n    Z", ascii);
+}
+
+// ============================================================================
+// Dialog TextInput Composition Tests
+// ============================================================================
+
+test "render TextInput in Column with label" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+    try input.insertSlice("hello");
+
+    var label_spans = [_]Text.Span{.{ .text = "Name:", .style = .{} }};
+
+    var children = [_]Widget{
+        .{ .kind = .{ .text = .{ .spans = &label_spans } } },
+        .{ .kind = .{ .text_input = .{ .input_id = 1, .input = &input } } },
+    };
+
+    var w: Widget = .{
+        .kind = .{ .column = .{ .children = &children, .cross_axis_align = .stretch } },
+    };
+
+    _ = w.layout(boundsConstraints(20, 2));
+
+    var screen = try tui_test.createScreen(allocator, 20, 2);
+    defer screen.deinit(allocator);
+    const win = tui_test.windowFromScreen(&screen);
+
+    try w.renderTo(win, allocator);
+
+    const ascii = try tui_test.screenToAscii(allocator, &screen, 20, 2);
+    defer allocator.free(ascii);
+
+    try tui_test.expectAsciiEqual("Name:               \nhello               ", ascii);
+
+    // Cursor at (5, 1) should be reversed
+    const cursor_cell = screen.readCell(5, 1).?;
+    try std.testing.expect(cursor_cell.style.reverse);
+
+    // Non-cursor cell should not be reversed
+    const normal_cell = screen.readCell(0, 1).?;
+    try std.testing.expect(!normal_cell.style.reverse);
+}
+
+test "render TextInput in Box+Padding dialog frame" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+    try input.insertSlice("abc");
+
+    var label_spans = [_]Text.Span{.{ .text = "Label", .style = .{} }};
+
+    var col_children = [_]Widget{
+        .{ .kind = .{ .text = .{ .spans = &label_spans } } },
+        .{ .kind = .{ .text_input = .{ .input_id = 1, .input = &input } } },
+    };
+
+    const col_widget: Widget = .{
+        .kind = .{ .column = .{ .children = &col_children, .cross_axis_align = .stretch } },
+    };
+
+    const pad_child = try allocator.create(Widget);
+    pad_child.* = col_widget;
+    defer allocator.destroy(pad_child);
+
+    const pad_widget: Widget = .{
+        .kind = .{ .padding = .{
+            .child = pad_child,
+            .top = 1,
+            .bottom = 1,
+            .left = 2,
+            .right = 2,
+        } },
+    };
+
+    const box_child = try allocator.create(Widget);
+    box_child.* = pad_widget;
+    defer allocator.destroy(box_child);
+
+    var w: Widget = .{
+        .kind = .{ .box = .{
+            .child = box_child,
+            .border = .rounded,
+            .style = .{},
+            .max_width = null,
+            .max_height = null,
+        } },
+    };
+
+    // border(2) + padding top/bottom(2) + 2 content rows = 6
+    _ = w.layout(boundsConstraints(20, 6));
+
+    var screen = try tui_test.createScreen(allocator, 20, 6);
+    defer screen.deinit(allocator);
+    const win = tui_test.windowFromScreen(&screen);
+
+    try w.renderTo(win, allocator);
+
+    const ascii = try tui_test.screenToAscii(allocator, &screen, 20, 6);
+    defer allocator.free(ascii);
+
+    // Row 0: rounded top border
+    // Row 1: padding top (border left/right edges)
+    // Row 2: "Label" offset by border(1) + padding left(2) = col 3
+    // Row 3: "abc" with cursor, same offset
+    // Row 4: padding bottom
+    // Row 5: rounded bottom border
     try tui_test.expectAsciiEqual(
-        \\     
-        \\     
-        \\    Z
+        \\╭──────────────────╮
+        \\│                  │
+        \\│  Label           │
+        \\│  abc             │
+        \\│                  │
+        \\╰──────────────────╯
     , ascii);
+
+    // Cursor inside dialog: border(1) + padding(2) + cursor after "abc" = col 6, row 3
+    const cursor_cell = screen.readCell(6, 3).?;
+    try std.testing.expect(cursor_cell.style.reverse);
+}
+
+test "render TextInput cursor in middle" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+    try input.insertSlice("hello");
+    input.moveLeft();
+    input.moveLeft();
+
+    var label_spans = [_]Text.Span{.{ .text = "Edit:", .style = .{} }};
+
+    var children = [_]Widget{
+        .{ .kind = .{ .text = .{ .spans = &label_spans } } },
+        .{ .kind = .{ .text_input = .{ .input_id = 1, .input = &input } } },
+    };
+
+    var w: Widget = .{
+        .kind = .{ .column = .{ .children = &children, .cross_axis_align = .stretch } },
+    };
+
+    _ = w.layout(boundsConstraints(20, 2));
+
+    var screen = try tui_test.createScreen(allocator, 20, 2);
+    defer screen.deinit(allocator);
+    const win = tui_test.windowFromScreen(&screen);
+
+    try w.renderTo(win, allocator);
+
+    // Cursor at position 3 in the input, which is col 3, row 1
+    const cursor_cell = screen.readCell(3, 1).?;
+    try std.testing.expect(cursor_cell.style.reverse);
+
+    // Adjacent cells should not be reversed
+    const before_cell = screen.readCell(2, 1).?;
+    try std.testing.expect(!before_cell.style.reverse);
+    const after_cell = screen.readCell(4, 1).?;
+    try std.testing.expect(!after_cell.style.reverse);
+}
+
+test "render TextInput scrolling in narrow viewport" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+    try input.insertSlice("abcdefghijklmnop");
+
+    var children = [_]Widget{
+        .{ .kind = .{ .text_input = .{ .input_id = 1, .input = &input } } },
+    };
+
+    var w: Widget = .{
+        .kind = .{ .column = .{ .children = &children, .cross_axis_align = .stretch } },
+    };
+
+    _ = w.layout(boundsConstraints(6, 1));
+
+    var screen = try tui_test.createScreen(allocator, 6, 1);
+    defer screen.deinit(allocator);
+    const win = tui_test.windowFromScreen(&screen);
+
+    try w.renderTo(win, allocator);
+
+    // After render, scroll_offset should have been updated
+    try std.testing.expect(input.scroll_offset > 0);
+
+    // Visible text should be the tail slice
+    const visible = input.visibleText(6);
+    try std.testing.expectEqualStrings("lmnop", visible);
+
+    // Cursor cell should be reversed
+    const cursor_pos = input.visibleCursorPos();
+    const cursor_cell = screen.readCell(@intCast(cursor_pos), 0).?;
+    try std.testing.expect(cursor_cell.style.reverse);
+}
+
+test "render empty TextInput" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+
+    var label_spans = [_]Text.Span{.{ .text = "Input:", .style = .{} }};
+
+    var children = [_]Widget{
+        .{ .kind = .{ .text = .{ .spans = &label_spans } } },
+        .{ .kind = .{ .text_input = .{ .input_id = 1, .input = &input } } },
+    };
+
+    var w: Widget = .{
+        .kind = .{ .column = .{ .children = &children, .cross_axis_align = .stretch } },
+    };
+
+    _ = w.layout(boundsConstraints(10, 2));
+
+    var screen = try tui_test.createScreen(allocator, 10, 2);
+    defer screen.deinit(allocator);
+    const win = tui_test.windowFromScreen(&screen);
+
+    try w.renderTo(win, allocator);
+
+    const ascii = try tui_test.screenToAscii(allocator, &screen, 10, 2);
+    defer allocator.free(ascii);
+
+    try tui_test.expectAsciiEqual("Input:    \n          ", ascii);
+
+    // Cursor at (0, 1) should be reversed
+    const cursor_cell = screen.readCell(0, 1).?;
+    try std.testing.expect(cursor_cell.style.reverse);
+}
+
+test "render TextInput with explicit style" {
+    const allocator = std.testing.allocator;
+
+    var input = TextInput.init(allocator);
+    defer input.deinit();
+    try input.insertSlice("hi");
+
+    var children = [_]Widget{
+        .{ .kind = .{ .text_input = .{
+            .input_id = 1,
+            .input = &input,
+            .style = .{ .fg = .{ .index = 2 }, .bg = .{ .index = 4 } },
+        } } },
+    };
+
+    var w: Widget = .{
+        .kind = .{ .column = .{ .children = &children, .cross_axis_align = .stretch } },
+    };
+
+    _ = w.layout(boundsConstraints(10, 1));
+
+    var screen = try tui_test.createScreen(allocator, 10, 1);
+    defer screen.deinit(allocator);
+    const win = tui_test.windowFromScreen(&screen);
+
+    try w.renderTo(win, allocator);
+
+    // Non-cursor cell should have fg=2, bg=4, not reversed
+    const normal_cell = screen.readCell(0, 0).?;
+    try std.testing.expectEqual(vaxis.Cell.Color{ .index = 2 }, normal_cell.style.fg);
+    try std.testing.expectEqual(vaxis.Cell.Color{ .index = 4 }, normal_cell.style.bg);
+    try std.testing.expect(!normal_cell.style.reverse);
+
+    // Cursor cell should have fg=2, bg=4, reversed
+    const cursor_cell = screen.readCell(2, 0).?;
+    try std.testing.expectEqual(vaxis.Cell.Color{ .index = 2 }, cursor_cell.style.fg);
+    try std.testing.expectEqual(vaxis.Cell.Color{ .index = 4 }, cursor_cell.style.bg);
+    try std.testing.expect(cursor_cell.style.reverse);
 }

--- a/src/widget.zig
+++ b/src/widget.zig
@@ -255,7 +255,6 @@ pub const Widget = struct {
                 surf.surface.render(win, self.focus);
             },
             .text_input => |ti| {
-                ti.input.updateScrollOffset(@intCast(win.width));
                 ti.input.render(win, ti.style);
             },
             .text => |text| {
@@ -4715,13 +4714,8 @@ test "render TextInput scrolling in narrow viewport" {
     // After render, scroll_offset should have been updated
     try std.testing.expect(input.scroll_offset > 0);
 
-    // Visible text should be the tail slice
-    const visible = input.visibleText(6);
-    try std.testing.expectEqualStrings("lmnop", visible);
-
-    // Cursor cell should be reversed
-    const cursor_pos = input.visibleCursorPos();
-    const cursor_cell = screen.readCell(@intCast(cursor_pos), 0).?;
+    // Cursor cell (last visible position) should be reversed
+    const cursor_cell = screen.readCell(5, 0).?;
     try std.testing.expect(cursor_cell.style.reverse);
 }
 


### PR DESCRIPTION
The existing TextInput uses a simple ArrayList for storage. Cursor
movement is byte-oriented, word-level operations are missing, and
editing behavior varies across dialog contexts.

Swap to vaxis's gap-buffer TextInput engine — prise already depends on
vaxis, so this uses its text editing infrastructure instead of a custom
implementation.

What changes:
- Grapheme-aware cursor movement (handles emoji and multi-byte characters)
- Readline keybindings: Ctrl-U/H/D/B/F, Alt-B/F/D, Alt-Backspace
- Alt+Backspace word deletion (previously fell through to plain backspace)
- Consistent editing across rename tab, rename session, command palette

Includes 6 dialog composition tests (layout, styling, cursor position,
scrolling, empty input, style propagation) and render tests for the
TextInput widget.

**API changes worth noting:**
- `text()` now returns `![]const u8` (allocated copy) instead of a direct buffer slice — necessary because the gap buffer stores data in two non-contiguous halves. Callers must free the result.
- `insert(char: u8)` removed — Lua's `insert()` now routes through `insertSlice`
- `render()` takes `*TextInput` instead of `*const TextInput` (now handles scroll offset internally)

I don't have the expertise to have a strong opinion on whether these are the right tradeoffs (especially `text()` allocating on every call), but it seemed worth raising in case there's a better way to handle any of them. Full analysis: https://gist.github.com/possibilities/4b6c80f699cbbb0ca7f5109d7ba599ad