### PR TITLE
tiling: deduplicate set_state test export

### DIFF
--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -4488,9 +4488,6 @@ M._test = {
     set_state = function(test_state)
         state.tabs = test_state.tabs or {}
         state.active_tab = test_state.active_tab or 1
-    set_state = function(test_state)
-        state.tabs = test_state.tabs or {}
-        state.active_tab = test_state.active_tab or 1
         state.next_tab_id = test_state.next_tab_id or (#state.tabs + 1) -- state.tabs already updated above
         state.focused_id = test_state.focused_id
         state.zoomed_pane_id = test_state.zoomed_pane_id
@@ -4501,14 +4498,6 @@ M._test = {
         state.tab_close_regions = {}
         state.pending_split = nil
         state.next_split_id = test_state.next_split_id or 1
-    end,
-        state.focused_id = test_state.focused_id
-        state.zoomed_pane_id = test_state.zoomed_pane_id
-        state.floating = { width = 0.8, height = 0.8, visible = false, pending = false, resize_mode = false }
-        state.hovered_tab = nil
-        state.hovered_close_tab = nil
-        state.tab_regions = {}
-        state.tab_close_regions = {}
     end,
     -- Returns a direct reference to internal state, not a copy
     get_state = function()


### PR DESCRIPTION
Collapse the duplicated `set_state = function(test_state)` entry in `M._test` back to a single function. 4633c30 inserted the new `pending_split` and `next_split_id` lines inside a second declaration of the same function, leaving the original body fragmented and an orphaned `end,` after it.

Result is a Lua parse error at `src/lua/tiling.lua:4505` — `zig build test` and `stylua --check src/lua` both fail on main right now.

Not urgent, just nice to get out of the way so builds and CI go green again — #112 and #114 pick up the same parse error after rebasing.