### PR TITLE
Add last_tab action for MRU tab toggle

### DIFF
--- a/docs/prise.5.md
+++ b/docs/prise.5.md
@@ -405,6 +405,9 @@ Zoom state is remembered per tab and restored when you switch back to that tab.
 **previous_tab**
 :   Switch to the previous tab
 
+**last_tab**
+:   Switch to the most-recently-active tab (tmux-style toggle)
+
 **tab_1** through **tab_10**
 :   Switch to tab by number
 

--- a/src/action.zig
+++ b/src/action.zig
@@ -32,6 +32,7 @@ pub const Action = union(enum) {
     rename_tab,
     next_tab,
     previous_tab,
+    last_tab,
     swap_tab_left,
     swap_tab_right,
 
@@ -119,6 +120,7 @@ pub const Action = union(enum) {
             .rename_tab => "Rename Tab",
             .next_tab => "Next Tab",
             .previous_tab => "Previous Tab",
+            .last_tab => "Last Tab",
             .swap_tab_left => "Swap Tab Left",
             .swap_tab_right => "Swap Tab Right",
             .tab_1 => "Tab 1",

--- a/src/lua/tiling.lua
+++ b/src/lua/tiling.lua
@@ -107,6 +107,7 @@ local utils = require("utils")
 ---@class State
 ---@field tabs Tab[]
 ---@field active_tab integer
+---@field previous_tab_id? integer
 ---@field next_tab_id integer
 ---@field focused_id? number
 ---@field zoomed_pane_id? number
@@ -380,6 +381,7 @@ local THEME = config.theme
 local state = {
     tabs = {},
     active_tab = 1,
+    previous_tab_id = nil,
     next_tab_id = 1,
     focused_id = nil,
     zoomed_pane_id = nil,
@@ -923,6 +925,9 @@ local function set_active_tab_index(new_index)
         old_tab.last_focused_id = state.focused_id
     end
 
+    -- Track previous active tab by id for last_tab toggle
+    state.previous_tab_id = old_tab and old_tab.id or nil
+
     state.active_tab = new_index
     local new_tab = state.tabs[new_index]
     if not new_tab then
@@ -944,6 +949,21 @@ local function set_active_tab_index(new_index)
     update_pty_focus(old_focused, new_focus_id)
     update_cached_git_branch()
     prise.request_frame()
+end
+
+---Switch to the most-recently-active tab (tmux-style toggle).
+---No-op if there is no recorded previous tab or the tab no longer exists.
+local function last_tab_action()
+    local prev_id = state.previous_tab_id
+    if not prev_id then
+        return
+    end
+    for idx, tab in ipairs(state.tabs) do
+        if tab.id == prev_id then
+            set_active_tab_index(idx)
+            return
+        end
+    end
 end
 
 ---Close the current tab
@@ -1578,6 +1598,7 @@ local function finalize_layout(pending)
     state.floating.height = new_floating_height
     state.floating.visible = new_floating_visible
     state.zoomed_pane_id = nil
+    state.previous_tab_id = nil
 
     -- Set active tab
     state.active_tab = layout.active_tab or 1
@@ -2112,6 +2133,13 @@ local commands = {
         end,
     },
     {
+        name = "Last Tab",
+        shortcut = key_prefix .. " " .. key_prefix,
+        action = function()
+            last_tab_action()
+        end,
+    },
+    {
         name = "Swap Tab Left",
         action = function()
             if state.active_tab > 1 then
@@ -2413,6 +2441,9 @@ action_handlers = {
             local prev_idx = (state.active_tab - 2 + #state.tabs) % #state.tabs + 1
             set_active_tab_index(prev_idx)
         end
+    end,
+    last_tab = function()
+        last_tab_action()
     end,
     swap_tab_left = function()
         if state.active_tab > 1 then
@@ -4422,6 +4453,7 @@ function M.set_state(saved, pty_lookup)
             state.next_tab_id = tab_id + 1
             state.focused_id = saved.focused_id
             state.next_split_id = saved.next_split_id or 1
+            state.previous_tab_id = nil
         end
     else
         -- New format: restore tabs
@@ -4442,6 +4474,7 @@ function M.set_state(saved, pty_lookup)
         state.next_tab_id = saved.next_tab_id or (#state.tabs + 1)
         state.focused_id = saved.focused_id
         state.next_split_id = saved.next_split_id or 1
+        state.previous_tab_id = nil
 
         -- Restore floating pane settings
         if saved.floating_settings then
@@ -4485,9 +4518,11 @@ M._test = {
     close_tab = close_tab,
     remove_pane_by_id = remove_pane_by_id,
     set_active_tab_index = set_active_tab_index,
+    last_tab_action = last_tab_action,
     set_state = function(test_state)
         state.tabs = test_state.tabs or {}
         state.active_tab = test_state.active_tab or 1
+        state.previous_tab_id = test_state.previous_tab_id
         state.next_tab_id = test_state.next_tab_id or (#state.tabs + 1) -- state.tabs already updated above
         state.focused_id = test_state.focused_id
         state.zoomed_pane_id = test_state.zoomed_pane_id

--- a/src/lua/tiling_test.lua
+++ b/src/lua/tiling_test.lua
@@ -190,3 +190,51 @@ assert(#item == 20, "format_palette_item: correct width")
 item = t.format_palette_item("Very Long Command Name", "C-x", 10)
 -- Width is too small, should use minimum padding of 2
 assert(item == "Very Long Command Name  C-x", "format_palette_item: minimum padding")
+
+-- === last_tab / previous_tab_id tracking ===
+
+-- Setup: three tabs with stable ids distinct from indices
+t.set_state({
+    tabs = {
+        { id = 10, root = mock_pane(101), last_focused_id = 101 },
+        { id = 20, root = mock_pane(102), last_focused_id = 102 },
+        { id = 30, root = mock_pane(103), last_focused_id = 103 },
+    },
+    active_tab = 1,
+})
+
+local st = t.get_state()
+assert(st.previous_tab_id == nil, "last_tab: fresh state has nil previous_tab_id")
+
+-- No previous yet: last_tab_action is a no-op
+t.last_tab_action()
+assert(st.active_tab == 1, "last_tab: no-op when no previous tab")
+
+-- Switch 1 -> 2: previous_tab_id tracks id of former tab (10), not its index (1)
+t.set_active_tab_index(2)
+assert(st.previous_tab_id == 10, "last_tab: previous_tab_id stores tab id, not index")
+
+-- Switch 2 -> 3: updated
+t.set_active_tab_index(3)
+assert(st.previous_tab_id == 20, "last_tab: previous_tab_id updates on each real switch")
+
+-- last_tab toggles back to tab with id 20 (at index 2)
+t.last_tab_action()
+assert(st.active_tab == 2, "last_tab: toggles to most-recently-active tab")
+assert(st.previous_tab_id == 30, "last_tab: toggle records formerly active tab as new previous")
+
+-- Ping-pong: another last_tab returns to tab with id 30 (index 3)
+t.last_tab_action()
+assert(st.active_tab == 3, "last_tab: ping-pong between two tabs works")
+
+-- Stale id: simulate the previous tab being closed. last_tab should be a no-op.
+t.set_state({
+    tabs = {
+        { id = 10, root = mock_pane(101), last_focused_id = 101 },
+        { id = 30, root = mock_pane(103), last_focused_id = 103 },
+    },
+    active_tab = 1,
+    previous_tab_id = 999, -- points at a tab that doesn't exist
+})
+t.last_tab_action()
+assert(st.active_tab == 1, "last_tab: stale previous_tab_id is a no-op")


### PR DESCRIPTION
## Summary

- Adds `last_tab` built-in action — switches to the most-recently-active tab (tmux `C-b l` semantics).
- Tracks previous tab by **id** in `state.previous_tab_id`; the hook lives in `set_active_tab_index`, which already early-returns when the target equals the current active tab, so the field only updates on real switches.
- Extracts a shared `last_tab_action` helper so the keybind action and the new "Last Tab" command palette entry share the same implementation.
- Documents `last_tab` in the Tab Management section of `prise.5`.
- Adds 4 assertions in `tiling_test.lua` covering initial nil, id-based tracking (not index), ping-pong toggle, and stale-id no-op.

## Motivation

`next_tab` / `previous_tab` move by position in the tab bar, not by MRU. There was no way to jump back to the previously active tab — the tmux muscle memory people expect. This adds that single action without introducing a full MRU stack.

## Test plan

- [x] `zig build` succeeds
- [x] `zig build test` passes (new assertions + no regressions)
- [x] Manual smoke:
  - Fresh session → `<leader><leader>` is a no-op (no previous)
  - Switch 1 → 2 → 3, `<leader><leader>` returns to 2; again returns to 3 (ping-pong)
  - Command palette shows "Last Tab" and selecting it behaves identically
  - Close a tab that was the previous → `<leader><leader>` is a silent no-op
  - Swap tabs → `<leader><leader>` still finds the right tab (id-based, not index-based)

## Notes

- State is ephemeral — omitted from `M.get_state`, so it is not persisted to session snapshots. Also cleared in both layout reload and `M.set_state` to avoid referencing a tab id that no longer exists after a live session switch.
- 1-deep toggle only; no MRU history stack. Keeps scope and state minimal.